### PR TITLE
Reloading doesn't reset the right hand menu anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # praxis changelog
 
+## next
+
+* The Doc Browser will now not change the menu when refreshing.
+
 ## 0.11.1
 
 * Fix `Stats` plugin to handle empty `args` hashes.
@@ -14,7 +18,7 @@
   * the new `:path` option will build the action routes by prefixing the version given a common pattern (i.e., "/v1.0/...")
     * The effects of path versioning will be visible through `rake praxis:routes`
     * the default api prefix pattern is ("/v(version)/") but can changed by either
-      * overriding ``Praxis::Request.path_version_prefix` and return the appropriate string prefix (i.e., by default this returns "/v") 
+      * overriding ``Praxis::Request.path_version_prefix` and return the appropriate string prefix (i.e., by default this returns "/v")
       * or overriding `Praxis::Request.path_version_matcher` and providing the fully custom matching regexp. This regexp must have a capture (named `version`) that would return matched version value.
 * Enhanced praxis generator:
   * Added a new generator (available through `praxis new app_name`) which creates a blank new app, with enough basic structure and setup to start building an API.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,8 @@ merged.
 Please do not add yourself to the `AUTHORS` file unless you are on the Praxis
 github team.
 
+Add a quick summary of your change to the changelog, under the `next` heading.
+
 ### Sign your work
 
 The sign-off is a simple line at the end of the explanation for the
@@ -181,4 +183,3 @@ There are several exceptions to the signing requirement. Currently these are:
 Don't forget: being a maintainer is a time investment. Make sure you will have
 time to make yourself available.  You don't have to be a maintainer to make a
 difference on the project!
-

--- a/lib/api_browser/app/js/controllers/menu.js
+++ b/lib/api_browser/app/js/controllers/menu.js
@@ -30,7 +30,7 @@ app.controller("MenuCtrl", function($scope, $state, Documentation) {
         links.push(link);
       });
     });
-    $scope.selectedVersion = $scope.versions[0];
+    $scope.selectedVersion = $state.params.version || $scope.versions[0];
 
   });
 


### PR DESCRIPTION
Previously reloading the doc browser wouldn't preserve the right hand menu's state:

![forget-history](https://cloud.githubusercontent.com/assets/69144/5647643/c93aa550-967f-11e4-9a60-585645b263d8.gif)

This PR fixes that so that the menu reflects the version in the URL.