### PR TITLE
Makes doc browser show proper links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## next
 
 * The Doc Browser will now not change the menu when refreshing.
+* Fixes an issue where URLs in the doc browser would display JSON.
 
 ## 0.11.1
 

--- a/lib/praxis/route.rb
+++ b/lib/praxis/route.rb
@@ -14,14 +14,14 @@ module Praxis
     def describe
       result = {
         verb: verb,
-        path: path,
+        path: path.to_s,
         version: version
       }
       result[:name] = name unless name.nil?
       result[:options] = options if options.any?
       result
     end
-    
+
   end
 
 end


### PR DESCRIPTION
Before we would see this for actions:

![screen shot 2015-01-07 at 15 40 25](https://cloud.githubusercontent.com/assets/69144/5648085/ae56d944-9683-11e4-90e8-ad93543f2e00.png)

This PR should fix it so that only the string part of the URL is shown as expected.