### PR TITLE
Uses proper tables for tabular data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * The Doc Browser will now not change the menu when refreshing.
 * Fixes an issue where URLs in the doc browser would display JSON.
+* Fixes an issue where table columns in the doc browser would be overlapping.
 
 ## 0.11.1
 

--- a/lib/api_browser/app/js/directives/attribute_table_row.js
+++ b/lib/api_browser/app/js/directives/attribute_table_row.js
@@ -1,6 +1,6 @@
 app.directive('rsAttributeTableRow', function($compile, TypeTemplates) {
   return {
-    restrict: 'E',
+    restrict: 'EA',
     scope: {
       name: '=',
       attribute: '='
@@ -8,7 +8,7 @@ app.directive('rsAttributeTableRow', function($compile, TypeTemplates) {
     link: function(scope, element, attrs) {
       // use the attribute type name to find the template
       var name = (scope.attribute.type ? scope.attribute.type.name : null) || 'default';
-      
+
       TypeTemplates.resolve(name).then(function(template) {
         element.replaceWith($compile(template)(scope));
       });

--- a/lib/api_browser/app/views/action.html
+++ b/lib/api_browser/app/views/action.html
@@ -43,40 +43,36 @@
   <div class="row" ng-if="hasResponses()">
     <div class="col-lg-12">
       <h2>Responses</h2>
-      <div class="attribute-table">
-        <div class="row head">
-          <div class="col-sm-2">
-            Code
-          </div>
-          <div class="col-sm-2">
-            Name
-          </div>
-          <div class="col-sm-4">
-            Media Type
-          </div>
-          <div class="col-sm-4">
-            Description
-          </div>
-        </div>
-        <div class="content">
-          <div class="row" ng-repeat="response in responses">
-            <div class="col-sm-2">
-              <span ng-if="response.isMultipart">
-                <em>Parts Like:</em>
-              </span>
-              <span>{{response.status}}</span>
-            </div>
-            <div class="col-sm-2">
-              {{response.name}}
-            </div>
-            <div class="col-sm-4">
-              {{response.media_type.name || response.media_type.identifier}}
-            </div>
-            <div class="col-sm-4">
-              <rs-attribute-description attribute="response"></rs-attribute-description>
-            </div>
-          </div>
-        </div>
+      <div class="table-responsive">
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>Code</th>
+              <th>Name</th>
+              <th>Media Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr ng-repeat="response in responses">
+              <td>
+                <span ng-if="response.isMultipart">
+                  <em>Parts Like:</em>
+                </span>
+                <span>{{response.status}}</span>
+              </td>
+              <td>
+                {{response.name}}
+              </td>
+              <td>
+                {{response.media_type.name || response.media_type.identifier}}
+              </td>
+              <td>
+                <rs-attribute-description attribute="response"></rs-attribute-description>
+              </td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
   </div>

--- a/lib/api_browser/app/views/directives/attribute_table.html
+++ b/lib/api_browser/app/views/directives/attribute_table.html
@@ -1,23 +1,17 @@
-﻿<div class="attribute-table">
-  <div class="row head">
-    <div class="col-sm-3">
-      Attribute
-    </div>
-    <div class="col-sm-2">
-      Type
-    </div>
-    <div class="col-sm-7">
-      Description
-    </div>
-  </div>
-  <div class="content">
-    <div ng-repeat="g in groups">
-      <div class="row" ng-if="g.name && g.attributes.length">
-        <div class="col-sm-12">
-          <strong>{{g.name}}</strong>
-        </div>
-      </div>
-      <rs-attribute-table-row ng-repeat="item in g.attributes" name="item.name" attribute="item"></rs-attribute-table-row>
-    </div>
-  </div>
+<div class="table-responsive">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Attribute</th>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody ng-repeat="g in groups">
+      <tr ng-if="g.name && g.attributes.length">
+        <th colspan="3">{{g.name}}</th>
+      </tr>
+      <tr rs-attribute-table-row ng-repeat="item in g.attributes" name="item.name" attribute="item" ></tr>
+    </tbody>
+  </table>
 </div>

--- a/lib/api_browser/app/views/directives/attribute_table_row/_default.html
+++ b/lib/api_browser/app/views/directives/attribute_table_row/_default.html
@@ -1,10 +1,10 @@
-﻿<div class="row">
-  <div class="col-sm-3" ng-bind-html="name | attributeName">
-  </div>
-  <div class="col-sm-2">
+<tr>
+  <td ng-bind-html="name | attributeName">
+  </td>
+  <td>
     <rs-type-label type="attribute.type"></rs-type-label>
-  </div>
-  <div class="col-sm-7">
+  </td>
+  <td>
     <rs-attribute-description attribute="attribute"></rs-attribute-description>
-  </div>
-</div>
+  </td>
+</tr>

--- a/lib/api_browser/app/views/directives/attribute_table_row/_links.html
+++ b/lib/api_browser/app/views/directives/attribute_table_row/_links.html
@@ -1,11 +1,11 @@
-<ng-include src="'views/directives/attribute_table_row/_default.html'" no-container></ng-include>
-<div class="row" ng-repeat="(attribute_name,attribute) in attribute.type.attributes">
-  <div class="col-sm-3" ng-bind-html="name + '.' + attribute_name | attributeName">
-  </div>
-  <div class="col-sm-2">
+<tr ng-include="'views/directives/attribute_table_row/_default.html'" no-container></tr>
+<tr ng-repeat="(attribute_name,attribute) in attribute.type.attributes">
+  <td ng-bind-html="name + '.' + attribute_name | attributeName">
+  </td>
+  <td>
 		 <rs-type-label type="attribute.type"></rs-type-label>
-  </div>
-  <div class="col-sm-7">
+  </td>
+  <td>
     <rs-attribute-description attribute="attribute"></rs-attribute-description>
-  </div>
-</div>
+  </td>
+</tr>

--- a/lib/api_browser/app/views/directives/attribute_table_row/_struct.html
+++ b/lib/api_browser/app/views/directives/attribute_table_row/_struct.html
@@ -1,2 +1,2 @@
-<ng-include src="'views/directives/attribute_table_row/_default.html'" no-container></ng-include>
-<rs-attribute-table-row ng-repeat="(k,v) in attribute.type.attributes" name="name + '.' + k" attribute="v"></rs-attribute-table-row>
+<tr ng-include="'views/directives/attribute_table_row/_default.html'" no-container></tr>
+<tr rs-attribute-table-row ng-repeat="(k,v) in attribute.type.attributes" name="name + '.' + k" attribute="v"></tr>

--- a/lib/api_browser/app/views/directives/request_body/_default.html
+++ b/lib/api_browser/app/views/directives/request_body/_default.html
@@ -1,20 +1,18 @@
-<div class="attribute-table">
-  <div class="row head">
-    <div class="col-sm-3">
-      Type
-    </div>
-    <div class="col-sm-9">
-      Type Attributes
-    </div>
-  </div>
-  <div class="content">
-  <div class="row head">
-    <div class="col-sm-3">
-      {{payload.type.name}}
-    </div>
-    <div class="col-sm-9">
-      <rs-attribute-description attribute="{options:{example:payload.example,typeData:payload.type}}"></rs-attribute-description>
-    </div>
-  </div>
-  </div>
+<div class="table-responsive">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Type Attributes</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>{{payload.type.name}}</td>
+        <td>
+          <rs-attribute-description attribute="{options:{example:payload.example,typeData:payload.type}}"></rs-attribute-description>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>

--- a/lib/api_browser/app/views/resource/_actions.html
+++ b/lib/api_browser/app/views/resource/_actions.html
@@ -1,29 +1,27 @@
-<div class="attribute-table">
-  <div class="row head">
-    <div class="col-sm-2">
-      Name
-    </div>
-    <div class="col-sm-4">
-      Route
-    </div>
-    <div class="col-sm-6">
-      Description
-    </div>
-  </div>
-  <div class="content">
-    <div class="row" ng-repeat="action in controller.actions">
-      <div class="col-sm-2">
-        <a ui-sref="root.action({action: action.name, controller: controllerName, version: apiVersion})">{{ action.name }}</a>
-      </div>
-      <div class="col-sm-4">
-        <div ng-repeat="url in action.urls">
-          <div class="label label-default">{{ url.verb }}</div>
-          <strong>{{ url.path }}</strong>
-        </div>
-      </div>
-      <div class="col-sm-6" style="font-size: 110%;">
-        {{ action.description }}
-      </div>
-    </div>
-  </div>
+<div class="table-responsive">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Route</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr ng-repeat="action in controller.actions">
+        <td>
+          <a ui-sref="root.action({action: action.name, controller: controllerName, version: apiVersion})">{{ action.name }}</a>
+        </td>
+        <td>
+          <div ng-repeat="url in action.urls">
+            <div class="label label-default">{{ url.verb }}</div>
+            <strong>{{ url.path }}</strong>
+          </div>
+        </td>
+        <td style="font-size: 110%;">
+          {{ action.description }}
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>


### PR DESCRIPTION
The doc browser was using divs to display tables. This is highly inaccessible (good luck with a screen reader) and breaks in the following ways:

1. Columns overlap:
      ![screen shot 2015-01-07 at 19 01 40](https://cloud.githubusercontent.com/assets/69144/5661034/c03273d0-971e-11e4-942c-cf41304f7dc4.png)
2. Breaks completely on mobile:
    ![screen shot 2015-01-08 at 10 12 28](https://cloud.githubusercontent.com/assets/69144/5661055/e6e44bfc-971e-11e4-9a7d-60b1f2d1e698.png)

This PR changes all of these to use proper tables. To solve these issues.
