### PR TITLE
Modified 'praxis generate' to 'praxis example' in docs

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -20,7 +20,7 @@ you'll need to install the Praxis gem.
 $ gem install praxis
 # or if your GEM_HOME is system-wide
 $ sudo gem install praxis
-$ praxis generate blog
+$ praxis example blog
       create  blog/app
       create  blog/design
       create  blog/lib


### PR DESCRIPTION
As `praxis generate` is now a deprecated command, the documentation should be updated to give the new command instead.