### PR TITLE
Use 'new' instead of 'setup!' for safety

### DIFF
--- a/lib/praxis/plugins/praxis_mapper_plugin.rb
+++ b/lib/praxis/plugins/praxis_mapper_plugin.rb
@@ -133,7 +133,7 @@ module Praxis
 
         included do
           before :action do |controller|
-            controller.request.identity_map = Praxis::Mapper::IdentityMap.setup!
+            controller.request.identity_map = Praxis::Mapper::IdentityMap.new
           end
         end
       end


### PR DESCRIPTION
When creating a Praxis::Mapper::IdentityMap using setup! it is possible to receive a previously created identity map that has already had finalize! called on it, resulting in the below error:

```#<RuntimeError: Denied for a pre-existing condition: Identity map has been used.>```

Using new creates a new IdentityMap every time and is generally safer.

Signed-off-by: Justin Gaylor <justin.gaylor@gmail.com>