### PR TITLE
Add nodoc! to ActionDefinition, ResourceDefinition, and MediaType.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # praxis changelog
 
+## next
+
+* Added `nodoc!` method to `ActionDefinition`, `ResourceDefinition`, and `MediaType` to hide actions, resources, and media types respectively from the generated documentation.
+
 ## 0.11.2
 
 * The Doc Browser will now not change the menu when refreshing.

--- a/lib/praxis/action_definition.rb
+++ b/lib/praxis/action_definition.rb
@@ -15,6 +15,7 @@ module Praxis
     attr_reader :primary_route
     attr_reader :named_routes
     attr_reader :responses
+    attr_reader :options
 
     class << self
       attr_accessor :doc_decorations      
@@ -30,6 +31,7 @@ module Praxis
       @name = name
       @resource_definition = resource_definition
       @responses = Hash.new
+      @options = Hash.new
 
       if (media_type = resource_definition.media_type)
         if media_type.kind_of?(Class) && media_type < Praxis::MediaType
@@ -161,6 +163,11 @@ module Praxis
         end
       end
     end
+
+    def nodoc!
+      options[:doc_visibility] = :nodoc
+    end
+
 
   end
 end

--- a/lib/praxis/media_type.rb
+++ b/lib/praxis/media_type.rb
@@ -30,6 +30,10 @@ module Praxis
       super(opts.merge(dsl_compiler: MediaType::DSLCompiler), &block)
     end
 
+    def self.nodoc!
+      self.options[:doc_visibility] = :nodoc
+    end
+    
     def links
       self.class::Links.new(@object)
     end

--- a/lib/praxis/media_type_collection.rb
+++ b/lib/praxis/media_type_collection.rb
@@ -61,12 +61,10 @@ module Praxis
       members = []
       size = rand(3) + 1
 
-
       size.times do |i|
         subcontext = context + ["at(#{i})"]
         members << @member_attribute.example(subcontext)
       end
-
 
       result.object._members = members
       result

--- a/lib/praxis/resource_definition.rb
+++ b/lib/praxis/resource_definition.rb
@@ -12,6 +12,7 @@ module Praxis
       @responses = Hash.new
       @action_defaults = []
       @version_options = {}
+      @options = {}
       Application.instance.resource_definitions << self
     end
 
@@ -20,7 +21,7 @@ module Praxis
       attr_reader :routing_config
       attr_reader :responses
       attr_reader :version_options
-      
+      attr_reader :options
       attr_accessor :controller
 
       # FIXME: this is inconsistent with the rest of the magic DSL convention.
@@ -102,6 +103,10 @@ module Praxis
           raise Exceptions::InvalidTrait.new("Trait #{trait_name} not found")
         end
         self.instance_eval(&ApiDefinition.instance.traits[trait_name])
+      end
+
+      def nodoc!
+        options[:doc_visibility] = :nodoc
       end
 
     end

--- a/lib/praxis/restful_doc_generator.rb
+++ b/lib/praxis/restful_doc_generator.rb
@@ -8,12 +8,25 @@ module Praxis
     @inspected_types = Set.new
     API_DOCS_DIRNAME = 'api_docs'
 
-    EXCLUDED_TYPES_FROM_TOP_LEVEL = Set.new( [Attributor::Boolean, Attributor::CSV, Attributor::DateTime, Attributor::Float, Attributor::Hash, Attributor::Ids, Attributor::Integer, Attributor::Object,  Attributor::String ] ).freeze
+    EXCLUDED_TYPES_FROM_TOP_LEVEL = Set.new([
+      Attributor::Boolean, 
+      Attributor::CSV,
+      Attributor::DateTime,
+      Attributor::Float,
+      Attributor::Hash,
+      Attributor::Ids,
+      Attributor::Integer,
+      Attributor::Object,
+      Attributor::String
+    ]).freeze
 
     def self.inspect_attributes(the_type)
 
       reachable = Set.new
       return reachable if the_type.nil? || the_type.is_a?(Praxis::SimpleMediaType)
+
+      # skip types with with visiblity of :nodoc
+      return reachable if the_type.options[:doc_visibility] == :nodoc
 
       # If an attribute comes in, get its type
       the_type = the_type.type if the_type.is_a? Attributor::Attribute
@@ -136,6 +149,9 @@ module Praxis
         resource_description = r.controller_config.describe
         # Go through the params/payload of each action and generate an example for them (then stick it into the description hash)
         r.controller_config.actions.each do |action_name, action|
+          # skip actions set to :nodoc
+          next if action.options[:doc_visibility] == :nodoc
+
           generated_examples = {}
           if action.params
             generated_examples[:params] = dump_example_for( r.id, action.params )

--- a/praxis.gemspec
+++ b/praxis.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ruport', '~> 1'
   spec.add_dependency 'mime', '~> 0'
   spec.add_dependency 'praxis-mapper', '~> 3.1'
-  spec.add_dependency 'praxis-blueprints', '~> 1.1'
+  spec.add_dependency 'praxis-blueprints', '~> 1.1.1'
   spec.add_dependency 'attributor', '~> 2.4.0'
   spec.add_dependency 'thor', '~> 0.18'
   spec.add_dependency 'terminal-table', '~> 1.4'

--- a/spec/praxis/action_definition_spec.rb
+++ b/spec/praxis/action_definition_spec.rb
@@ -140,4 +140,16 @@ describe Praxis::ActionDefinition do
     end
 
   end
+
+  context 'with nodoc! option' do
+    before do
+      action.nodoc!      
+    end
+
+    it 'has the :doc_visibility set' do
+      expect(action.options[:doc_visibility]).to be(:nodoc)
+    end
+
+  end
+
 end

--- a/spec/praxis/action_definition_spec.rb
+++ b/spec/praxis/action_definition_spec.rb
@@ -38,6 +38,7 @@ describe Praxis::ActionDefinition do
     its('payload.attributes')  { should have_key :inherited }
     its('headers.attributes')  { should have_key "X_REQUESTED_WITH" }
     its('headers.attributes')  { should have_key "Inherited" }
+    its('options') { should_not have_key :doc_visibility }
   end
 
   context '#responses' do

--- a/spec/praxis/media_type_spec.rb
+++ b/spec/praxis/media_type_spec.rb
@@ -74,6 +74,22 @@ describe Praxis::MediaType do
     end
   end
 
+  context 'with nodoc! option' do
+    subject(:media_type) do
+      Class.new(Praxis::MediaType) do
+        nodoc!
+        attributes do
+          attribute :name, String
+        end
+      end
+    end
+
+    it 'has the :doc_visibility set' do
+      expect(media_type.options[:doc_visibility]).to be(:nodoc)
+    end
+
+  end
+
   context 'using blueprint caching' do
     it 'has specs'
   end

--- a/spec/praxis/media_type_spec.rb
+++ b/spec/praxis/media_type_spec.rb
@@ -10,6 +10,7 @@ describe Praxis::MediaType do
 
   subject(:address) { Address.new(resource) }
 
+
   context 'attributes' do
     its(:id)    { should eq(1) }
     its(:name)  { should eq('Home') }
@@ -74,23 +75,30 @@ describe Praxis::MediaType do
     end
   end
 
-  context 'with nodoc! option' do
-    subject(:media_type) do
-      Class.new(Praxis::MediaType) do
-        nodoc!
-        attributes do
-          attribute :name, String
+  context 'options' do
+    it 'does not have doc_visiblity set by default' do
+      expect(Address.options).to_not have_key(:doc_visiblity)
+    end
+
+    context 'with nodoc! called' do
+      subject(:media_type) do
+        Class.new(Praxis::MediaType) do
+          nodoc!
+          attributes do
+            attribute :name, String
+          end
         end
       end
+
+      it 'has the :doc_visibility set to :nodoc' do
+        expect(media_type.options[:doc_visibility]).to be(:nodoc)
+      end
+
+
     end
 
-    it 'has the :doc_visibility set' do
-      expect(media_type.options[:doc_visibility]).to be(:nodoc)
+    context 'using blueprint caching' do
+      it 'has specs'
     end
-
-  end
-
-  context 'using blueprint caching' do
-    it 'has specs'
   end
 end

--- a/spec/praxis/resource_definition_spec.rb
+++ b/spec/praxis/resource_definition_spec.rb
@@ -97,4 +97,16 @@ describe Praxis::ResourceDefinition do
     end
 
   end
+
+  context 'with nodoc! option' do
+    before do
+      resource_definition.nodoc!      
+    end
+
+    it 'has the :doc_visibility set' do
+      expect(resource_definition.options[:doc_visibility]).to be(:nodoc)
+    end
+
+  end
+
 end

--- a/spec/praxis/resource_definition_spec.rb
+++ b/spec/praxis/resource_definition_spec.rb
@@ -12,8 +12,7 @@ describe Praxis::ResourceDefinition do
   its(:routing_config) { should be_kind_of(Proc) }
 
   its(:actions) { should have(2).items }
-
-
+  its(:options) { should_not have_key(:doc_visibility) }
 
   context '.describe' do
     subject(:describe) { resource_definition.describe }
@@ -98,12 +97,12 @@ describe Praxis::ResourceDefinition do
 
   end
 
-  context 'with nodoc! option' do
+  context 'with nodoc! called' do
     before do
       resource_definition.nodoc!      
     end
 
-    it 'has the :doc_visibility set' do
+    it 'has the :doc_visibility option set' do
       expect(resource_definition.options[:doc_visibility]).to be(:nodoc)
     end
 


### PR DESCRIPTION
This updates a new doc_visibility option to the value of :nodoc, which is used
by the RestfulDocGenerator to skip generation for objects with it set.

Closes #74