### PR TITLE
Fixes #97: default false not showing in docbrowser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added `nodoc!` method to `ActionDefinition`, `ResourceDefinition` to hide actions and resources from the generated documentation.
 * Added descriptions to the default HTTP responses.
 * Replaced Ruport dependency in `praxis:routes` rake task with TerminalTable.
+* Fixed doc browser issue when attributes defaulting to false wouldn't display the default section.
 
 ## 0.11.2
 

--- a/lib/api_browser/app/js/controllers/action.js
+++ b/lib/api_browser/app/js/controllers/action.js
@@ -18,8 +18,8 @@ app.controller("ActionCtrl", function($scope, $stateParams, Documentation) {
           var example = set.example ? JSON.stringify(set.example[name], null, 2) : '';
           if (!attribute.options) attribute.options = {};
           if (example) attribute.options.example = example;
-          if (attribute.values) attribute.options.values = attribute.values;
-          if (attribute.default) attribute.options.default = attribute.default;
+          if (attribute.values != null) attribute.options.values = attribute.values;
+          if (attribute.default != null) attribute.options.default = attribute.default;
         });
       }
     });

--- a/lib/api_browser/app/js/controllers/type.js
+++ b/lib/api_browser/app/js/controllers/type.js
@@ -15,8 +15,8 @@
       var example = JSON.stringify($scope.type.example[name], null, 2);
       if (!attribute.options) attribute.options = {};
       if (example) attribute.options.example = example;
-      if (attribute.values) attribute.options.values = attribute.values;
-      if (attribute.default) attribute.options.default = attribute.default;
+      if (attribute.values != null) attribute.options.values = attribute.values;
+      if (attribute.default != null) attribute.options.default = attribute.default;
     });
 
     Documentation.getIndex().success(function(response) {


### PR DESCRIPTION
Was caused by a boolean check instead of a nil check. Fixes similar potential issue in some other places.