### PR TITLE
Dump PraxisMapper stats at debug level

### DIFF
--- a/lib/praxis/plugins/praxis_mapper_plugin.rb
+++ b/lib/praxis/plugins/praxis_mapper_plugin.rb
@@ -141,7 +141,7 @@ module Praxis
       module Statistics
 
         def self.log(identity_map, log_stats)
-          return if identity_map.nil?
+          return if identity_map.nil? || identity_map.queries.empty?
           case log_stats
           when 'detailed'
             self.detailed(identity_map)
@@ -187,7 +187,7 @@ module Praxis
           table.align_column(3, :right)
           table.align_column(4, :right)
           table.align_column(5, :right)
-          Praxis::Application.instance.logger.info "Praxis::Mapper Statistics:\n#{table.to_s}"
+          Praxis::Application.instance.logger.debug "Praxis::Mapper Statistics:\n#{table.to_s}"
         end
 
         def self.round_fields_at(values, indices)
@@ -197,7 +197,7 @@ module Praxis
         end
 
         def self.short(identity_map)
-          Praxis::Application.instance.logger.info "Praxis::Mapper Statistics: #{identity_map.query_statistics.sum_totals.to_s}"
+          Praxis::Application.instance.logger.debug "Praxis::Mapper Statistics: #{identity_map.query_statistics.sum_totals.to_s}"
         end
       end
     end

--- a/lib/praxis/plugins/praxis_mapper_plugin.rb
+++ b/lib/praxis/plugins/praxis_mapper_plugin.rb
@@ -141,7 +141,11 @@ module Praxis
       module Statistics
 
         def self.log(identity_map, log_stats)
-          return if identity_map.nil? || identity_map.queries.empty?
+          return if identity_map.nil?
+          if identity_map.queries.empty?
+            Praxis::Application.instance.logger.debug "Praxis::Mapper Statistics: No database interactions observed."
+            return
+          end
           case log_stats
           when 'detailed'
             self.detailed(identity_map)

--- a/spec/praxis/plugins/praxis_mapper_plugin_spec.rb
+++ b/spec/praxis/plugins/praxis_mapper_plugin_spec.rb
@@ -32,12 +32,9 @@ describe Praxis::Plugins::PraxisMapperPlugin do
     let(:session) { double("session", valid?: true)}
 
     around(:each) do |example|
-      orig_level = Praxis::Application.instance.logger.level
-      Praxis::Application.instance.logger.level = 2
       config.log_stats = 'detailed'; plugin.setup!
       example.run
       config.log_stats = 'skip'; plugin.setup!
-      Praxis::Application.instance.logger.level = orig_level
     end
 
     it 'logs stats' do
@@ -54,7 +51,7 @@ describe Praxis::Plugins::PraxisMapperPlugin do
 
   context 'Statistics' do
     context '.log' do
-      let(:identity_map) { double('identity_map') }
+      let(:identity_map) { double('identity_map', queries: {query: true} ) }
 
       it 'when log_stats = detailed' do
         expect(Praxis::Plugins::PraxisMapperPlugin::Statistics).to receive(:detailed).with(identity_map)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,11 @@ RSpec.configure do |config|
       hash[key] = Hash.new
     end
   end
+
+  config.before(:all) do
+    # disable debug logging (to avoid PraxisMapper plugin logging)
+    Praxis::Application.instance.logger.level = 1 # info
+  end
 end
 
 # create the test db schema

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,11 +42,6 @@ RSpec.configure do |config|
       hash[key] = Hash.new
     end
   end
-
-  config.before(:all) do
-    # disable logging below warn level
-    Praxis::Application.instance.logger.level = 2 # warn
-  end
 end
 
 # create the test db schema


### PR DESCRIPTION
Dump PraxisMapper stats at debug level
    
This removes the need to for the debug level above debug when running specs and prevents noisy logs. Also, I updated the plugin to NOT log the stats if no queries have been done.

This fixes https://github.com/rightscale/praxis/issues/107
    
Signed-off-by: Justin Gaylor <justin.gaylor@gmail.com>