### PR TITLE
Enhanced several logging aspects of the PraxisMapper plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Enhanced several logging aspects of the PraxisMapper plugin:
   * The log-level of the stats is now configurable in the plugin (see the comments [here](https://github.com/rightscale/praxis/blob/master/lib/praxis/plugins/praxis_mapper_plugin.rb) for details)
   * Added a "silence_mapper_stats" attribute in the Request objects so, actions and/or controllers can selectively skip logging stats (for example, health check controllers, etc)
-  * It now logs a compact message (with the same heading) when the identity map has had interactions.
+  * It now logs a compact message (with the same heading) when the identity map has had no interactions.
 
 ## 0.11.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Replaced Ruport dependency in `praxis:routes` rake task with TerminalTable.
 * Fixed doc browser issue when attributes defaulting to false wouldn't display the default section.
 * Enhanced several logging aspects of the PraxisMapper plugin:
-  * The log-level of the stats is now configurable in the plugin (see the comments [here(https://github.com/rightscale/praxis/blob/master/lib/praxis/plugins/praxis_mapper_plugin.rb) for details)
+  * The log-level of the stats is now configurable in the plugin (see the comments [here](https://github.com/rightscale/praxis/blob/master/lib/praxis/plugins/praxis_mapper_plugin.rb) for details)
   * Added a "silence_mapper_stats" attribute in the Request objects so, actions and/or controllers can selectively skip logging stats (for example, health check controllers, etc)
   * It now logs a compact message (with the same heading) when the identity map has had interactions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 * Added descriptions to the default HTTP responses.
 * Replaced Ruport dependency in `praxis:routes` rake task with TerminalTable.
 * Fixed doc browser issue when attributes defaulting to false wouldn't display the default section.
+* Enhanced several logging aspects of the PraxisMapper plugin:
+  * The log-level of the stats is now configurable in the plugin (see the comments [here(https://github.com/rightscale/praxis/blob/master/lib/praxis/plugins/praxis_mapper_plugin.rb) for details)
+  * Added a "silence_mapper_stats" attribute in the Request objects so, actions and/or controllers can selectively skip logging stats (for example, health check controllers, etc)
+  * It now logs a compact message (with the same heading) when the identity map has had interactions.
 
 ## 0.11.2
 


### PR DESCRIPTION
  * configurable log-level
  * Can skip logs at the individual request level
  * Short message when identity map has had interactions.

Fixes #107, fixes #108, fixes #109

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>