### PR TITLE
Added a handy option to tie an action route to match any HTTP verb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   * Configured with boolean `praxis.x_cascade` that defaults to true.
   * When enabled, Praxis will add an 'X-Cascade: pass' header to the response when the request was not routable to an action. It is not added if the action explicitly returns a `NotFound` response.
 * Fixed bug in request handling where `after` callbacks were being executed, even if the stage returned a response.
+* Added a handy option to tie an action route to match any HTTP verb.
+  * Simply use `any` as the verb when you define it (i.e. any '/things/:id' )
 
 ## 0.11.2
 

--- a/lib/praxis/router.rb
+++ b/lib/praxis/router.rb
@@ -64,7 +64,17 @@ module Praxis
       end
 
       verb = request.verb
-      result = @routes[verb].call(request)
+      r = ( @routes.key?(verb) ? @routes[verb] : nil )  # Exact verb match
+      result = r.call(request) if r
+      # If we didn't have an exact verb route, or if we did but the rest or route conditions didn't match
+      if( r == nil || result == :not_found )
+         # Fallback to a wildcard router, if there is one registered
+        result = if @routes.key?('ANY')
+           @routes['ANY'].call(request)
+         else
+           :not_found
+         end
+      end
       
       if result == :not_found
         # no need to try :path as we cannot really know if you've attempted to pass a version through it here

--- a/lib/praxis/skeletor/restful_routing_config.rb
+++ b/lib/praxis/skeletor/restful_routing_config.rb
@@ -39,6 +39,9 @@ module Praxis
       def trace(path, opts={})   add_route 'TRACE',   path, opts end
       def connect(path, opts={}) add_route 'CONNECT', path, opts end
       def patch(path, opts={})   add_route 'PATCH',   path, opts end
+      def any(path, opts={})     add_route 'ANY',       path, opts end
+
+        
 
       def add_route(verb, path, options={})
         path = Mustermann.new(prefix + path)

--- a/spec/functional_spec.rb
+++ b/spec/functional_spec.rb
@@ -256,6 +256,18 @@ describe 'Functional specs' do
     end
   end
 
+  context 'wildcard routing' do
+    it 'can terminate instances with POST' do
+      post '/clouds/23/instances/1/terminate?api_version=1.0', nil, 'global_session' => session
+      expect(last_response.status).to eq(200)
+    end
+    it 'can terminate instances with DELETE' do
+      post '/clouds/23/instances/1/terminate?api_version=1.0', nil, 'global_session' => session
+      expect(last_response.status).to eq(200)
+    end
+
+  end
+  
   context 'auth_plugin' do
     it 'can terminate' do
       post '/clouds/23/instances/1/terminate?api_version=1.0', nil, 'global_session' => session

--- a/spec/praxis/restful_routing_config_spec.rb
+++ b/spec/praxis/restful_routing_config_spec.rb
@@ -88,7 +88,7 @@ describe Praxis::Skeletor::RestfulRoutingConfig do
     let(:route_prefix) { nil }
 
     it 'call the add_route with the correct parameters' do
-      helper_verbs = [:get, :put, :post, :delete, :head, :options, :patch ]
+      helper_verbs = [:get, :put, :post, :delete, :head, :options, :patch, :any]
       helper_verbs.each do |verb|
         path = "/path_for_#{verb}"
         options = {option: verb}

--- a/spec/spec_app/design/resources/instances.rb
+++ b/spec/spec_app/design/resources/instances.rb
@@ -130,7 +130,7 @@ module ApiResources
 
     action :terminate do
       routing do
-        post '/:id/terminate'
+        any '/:id/terminate'
       end
       
       requires_ability :terminate


### PR DESCRIPTION
To use it, employ the `any` DSL word when defining a route: 

```ruby
routing do
  any '/things/:id’
end
```

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>