### PR TITLE
Definition and handling of canonical urls for API resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@
   * Currently, "ids" are generated using dashes instead of double colons (instead of random ids). This closes issue #31.
 * Added the definition and handling of canonical urls for API resources
   * One can now specify which action URL should be considered as the canonical resource href:
-    * by using `canonical_path_action <action_name>` at the top of the resource definition class
-    * or by using `canonical_path` within the action definition itself.
+    * by using `canonical_path <action_name>` at the top of the resource definition class
     * See the [instances](https://github.com/rightscale/praxis/blob/master/spec/spec_app/design/resources/instances.rb) resource definition for an example.
   * With a canonical href defined, one can then both generate and parse them by using:
     * `.to_href(<named arguments hash>)  =>  <href String>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## next
 
+* First pass at describing (and doc-generating) API global information
+  * Inside a `Praxis::ApiDefinition.define` block one can now specify a few things about the API by using:
+    * info("1.0") `<block>` - Which will apply to a particular version only
+    * info `<block>` - Which will be inherited by any existing API version
+    * The current pieces of information that can be defined in the block are: `name`, `title`, `description` and `basepath`. See [this](https://github.com/rightscale/praxis/blob/master/spec/spec_app/design/api.rb) for details
+  * NOTE: This information is output to the JSON files, BUT not used in the doc browser yet.
+* Changed the doc generation and browser to use "ids" instead of "names" for routes and generated files.
+  * Currently, "ids" are generated using dashes instead of double colons (instead of random ids). This closes issue #31.
+* Added the definition and handling of canonical urls for API resources
+  * One can now specify which action URL to be considered as the canonical resource href:
+    * by using `canonical_path_action <action_name>` at the top of the resource definition class
+    * or by using `canonical_path` within the action definition itself.
+    * See the [instances](https://github.com/rightscale/praxis/blob/master/spec/spec_app/design/resources/instances.rb) resource definition for an example.
+  * With a canonical href defined, one can then both generate and parse them by using:
+    * `.to_href(<named arguments hash>)  =>  <href String>`
+    * `.parse_href( <href String> )  => < named arguments hash >`. Note: The returned arguments are properly typed-coerced.
+    * These helpers can be accessed from:
+      * the `definition` object in the controller instance (i.e., `self.definition.to_href(id: 1). )
+      * or through the class-level methods in the resource definition (i.e. `MyApiResource.parse_href("/my_resource/1")` )
+
 ## 0.13.0
 
 * Added `nodoc!` method to `ActionDefinition`, `ResourceDefinition` to hide actions and resources from the generated documentation.
@@ -22,14 +42,6 @@
   * Simply use `any` as the verb when you define it (i.e. any '/things/:id' )
 * Allow a MediaType to define a custom `links` attribute like any other.
   * This is not compatible if it also wants to use the `links` DSL.
-* First pass at describing (and doc-generating) API global information
-  * Inside a `Praxis::ApiDefinition.define` block one can now specify a few things about the API by using:
-    * info("1.0") `<block>` - Which will apply to a particular version only
-    * info `<block>` - Which will be inherited by any existing API version
-    * The current pieces of information that can be defined in the block are: `name`, `title`, `description` and `basepath`. See [this](https://github.com/rightscale/praxis/blob/master/spec/spec_app/design/api.rb) for details
-  * NOTE: This information is output to the JSON files, BUT not used in the doc browser yet.
-* Changed the doc generation and browser to use "ids" instead of "names" for routes and generated files.
-  * Currently, "ids" are generated using dashes instead of double colons (instead of random ids). This closes issue #31.
 
 
 ## 0.11.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Changed the doc generation and browser to use "ids" instead of "names" for routes and generated files.
   * Currently, "ids" are generated using dashes instead of double colons (instead of random ids). This closes issue #31.
 * Added the definition and handling of canonical urls for API resources
-  * One can now specify which action URL to be considered as the canonical resource href:
+  * One can now specify which action URL should be considered as the canonical resource href:
     * by using `canonical_path_action <action_name>` at the top of the resource definition class
     * or by using `canonical_path` within the action definition itself.
     * See the [instances](https://github.com/rightscale/praxis/blob/master/spec/spec_app/design/resources/instances.rb) resource definition for an example.

--- a/lib/praxis/action_definition.rb
+++ b/lib/praxis/action_definition.rb
@@ -31,7 +31,7 @@ module Praxis
     end
 
     def initialize(name, resource_definition, **opts, &block)
-      @name = name
+      @name = name.to_sym
       @resource_definition = resource_definition
       @responses = Hash.new
       @metadata = Hash.new

--- a/lib/praxis/action_definition.rb
+++ b/lib/praxis/action_definition.rb
@@ -74,6 +74,10 @@ module Praxis
       self.instance_eval(&ApiDefinition.instance.traits[trait_name])
     end
 
+    def canonical_path
+      resource_definition.canonical_path_action self.name
+    end
+    
     def params(type=Attributor::Struct, **opts, &block)
       return @params if !block && type == Attributor::Struct
 

--- a/lib/praxis/action_definition.rb
+++ b/lib/praxis/action_definition.rb
@@ -31,7 +31,7 @@ module Praxis
     end
 
     def initialize(name, resource_definition, **opts, &block)
-      @name = name.to_sym
+      @name = name
       @resource_definition = resource_definition
       @responses = Hash.new
       @metadata = Hash.new

--- a/lib/praxis/action_definition.rb
+++ b/lib/praxis/action_definition.rb
@@ -73,10 +73,6 @@ module Praxis
       end
       self.instance_eval(&ApiDefinition.instance.traits[trait_name])
     end
-
-    def canonical_path
-      resource_definition.canonical_path_action self.name
-    end
     
     def params(type=Attributor::Struct, **opts, &block)
       return @params if !block && type == Attributor::Struct

--- a/lib/praxis/controller.rb
+++ b/lib/praxis/controller.rb
@@ -33,5 +33,8 @@ module Praxis
       @response = response
     end
 
+    def definition
+      self.class.definition
+    end
   end
 end

--- a/lib/praxis/request.rb
+++ b/lib/praxis/request.rb
@@ -4,15 +4,26 @@ module Praxis
     attr_reader :env, :query
     attr_accessor :route_params, :action
 
+    PATH_VERSION_PREFIX = "/v".freeze
+    PATH_VERSION_MATCHER = %r{^#{PATH_VERSION_PREFIX}(?<version>[^\/]+)\/}.freeze
+    CONTENT_TYPE_NAME = 'CONTENT_TYPE'.freeze
+    PATH_INFO_NAME = 'PATH_INFO'.freeze
+    REQUEST_METHOD_NAME = 'REQUEST_METHOD'.freeze
+    QUERY_STRING_NAME = 'QUERY_STRING'.freeze
+    API_VERSION_HEADER_NAME = "HTTP_X_API_VERSION".freeze
+    API_VERSION_PARAM_NAME = 'api_version'.freeze
+    API_NO_VERSION_NAME = 'n/a'.freeze
+    VERSION_USING_DEFAULTS = [:header,:params].freeze
+    
     def initialize(env)
       @env = env
-      @query = Rack::Utils.parse_nested_query(env['QUERY_STRING'.freeze])
+      @query = Rack::Utils.parse_nested_query(env[QUERY_STRING_NAME])
       @route_params = {}
       @path_version_matcher = path_version_matcher
     end
 
     def content_type
-      @env['CONTENT_TYPE'.freeze]
+      @env[CONTENT_TYPE_NAME]
     end
 
     # The media type (type/subtype) portion of the CONTENT_TYPE header
@@ -26,7 +37,7 @@ module Praxis
     end
 
     def path
-      @env['PATH_INFO'.freeze]
+      @env[PATH_INFO_NAME]
     end
 
     attr_accessor :headers, :params, :payload
@@ -40,13 +51,13 @@ module Praxis
     end
 
     def verb
-      @env['REQUEST_METHOD'.freeze]
+      @env[REQUEST_METHOD_NAME]
     end
 
     def raw_params
       @raw_params ||= begin
         params = query.merge(route_params)
-        params.delete('api_version'.freeze)
+        params.delete(API_VERSION_PARAM_NAME)
         params
       end
     end
@@ -66,21 +77,21 @@ module Praxis
     end
     
     def self.path_version_prefix
-      "/v".freeze
+      PATH_VERSION_PREFIX
     end
     
     def path_version_matcher
-      %r{^#{Request.path_version_prefix}(?<version>[^\/]+)\/}.freeze
+      PATH_VERSION_MATCHER
     end
     
-    def version(using: [:header,:params].freeze)
+    def version(using: VERSION_USING_DEFAULTS )
       result = nil
       Array(using).find do |mode|
         case mode
         when :header ;
-          result = env["HTTP_X_API_VERSION".freeze]
+          result = env[API_VERSION_HEADER_NAME]
         when :params ;
-          result = @query['api_version'.freeze]
+          result = @query[API_VERSION_PARAM_NAME]
         when :path ;
           m = self.path.match(@path_version_matcher) 
           result = m[:version] unless m.nil?
@@ -88,7 +99,7 @@ module Praxis
           raise "Unknown method for retrieving the API version: #{mode}"
         end
       end
-      return result || 'n/a'.freeze
+      return result || API_NO_VERSION_NAME
     end
 
     def load_headers(context)

--- a/lib/praxis/request.rb
+++ b/lib/praxis/request.rb
@@ -5,7 +5,6 @@ module Praxis
     attr_accessor :route_params, :action
 
     PATH_VERSION_PREFIX = "/v".freeze
-    PATH_VERSION_MATCHER = %r{^#{PATH_VERSION_PREFIX}(?<version>[^\/]+)\/}.freeze
     CONTENT_TYPE_NAME = 'CONTENT_TYPE'.freeze
     PATH_INFO_NAME = 'PATH_INFO'.freeze
     REQUEST_METHOD_NAME = 'REQUEST_METHOD'.freeze
@@ -79,6 +78,8 @@ module Praxis
     def self.path_version_prefix
       PATH_VERSION_PREFIX
     end
+
+    PATH_VERSION_MATCHER = %r{^#{self.path_version_prefix}(?<version>[^\/]+)\/}.freeze
     
     def path_version_matcher
       PATH_VERSION_MATCHER

--- a/lib/praxis/request_stages/request_stage.rb
+++ b/lib/praxis/request_stages/request_stage.rb
@@ -11,7 +11,7 @@ module Praxis
       alias :dispatcher :application # it's technically application in the base Stage
 
       def path
-        [name]
+        @the_path ||= [name].freeze
       end
 
       def execute_controller_callbacks(callbacks)

--- a/lib/praxis/resource_definition.rb
+++ b/lib/praxis/resource_definition.rb
@@ -1,11 +1,11 @@
 require 'active_support/concern'
 require 'active_support/inflector'
 
-
 module Praxis
   module ResourceDefinition
     extend ActiveSupport::Concern
-
+    DEFAULT_RESOURCE_HREF_ACTION = :show
+    
     included do
       @version = 'n/a'.freeze
       @actions = Hash.new
@@ -48,6 +48,36 @@ module Praxis
         @version_options = options
       end
 
+      def canonical_path_action( action_name=nil )
+        if action_name
+          raise "Action '#{@canonical_action_name}' has already been selected as the canonical path for #{self.name}" if @canonical_action_name
+          @canonical_action_name = action_name
+        else
+          unless @canonical_action
+            href_action = @canonical_action_name || DEFAULT_RESOURCE_HREF_ACTION
+            @canonical_action = actions[href_action]
+            raise "Error: trying to set canonical_href of #{self.name}. Action '#{href_action}' does not exist" unless @canonical_action
+          end
+          return @canonical_action
+        end
+      end
+      
+      def to_href( params )
+        canonical_path_action.primary_route.path.expand(params)
+      end
+
+      def parse_href( path )
+        param_values=canonical_path_action.primary_route.path.match(path)
+        attrs=canonical_path_action.params.attributes
+        idx = 0
+        param_values.names.each_with_object({}) do |key,hash|
+          hash[key.to_sym] = attrs[key.to_sym].load(param_values.captures[idx],[key])
+          idx +=1
+        end
+      rescue => e
+        raise Praxis::Exception.new("Error parsing or coercing parameters from href: #{path}\n"+e.message)
+      end
+      
       def action_defaults(&block)
         return @action_defaults unless block_given?
 

--- a/lib/praxis/resource_definition.rb
+++ b/lib/praxis/resource_definition.rb
@@ -115,6 +115,7 @@ module Praxis
 
       def action(name, &block)
         raise ArgumentError, "can not create ActionDefinition without block" unless block_given?
+        raise ArgumentError, "Action names must be defined using symbols (Got: #{name} (of type #{name.class}))" unless name.is_a? Symbol
         @actions[name] = ActionDefinition.new(name, self, &block)
       end
 

--- a/spec/praxis/action_definition_spec.rb
+++ b/spec/praxis/action_definition_spec.rb
@@ -22,7 +22,6 @@ describe Praxis::ActionDefinition do
 
   subject(:action) do
     Praxis::ActionDefinition.new('foo', resource_definition) do
-      canonical_path
       routing { get '/:one' }
       payload { attribute :two, String }
       headers { header "X_REQUESTED_WITH", 'XMLHttpRequest' }
@@ -156,14 +155,5 @@ describe Praxis::ActionDefinition do
       expect(action.describe[:metadata][:doc_visibility]).to be(:none)
     end
 
-  end
-
-  context '#canonical_path' do
-    it 'will notify its parent resource_definition with its action name' do
-      expect(action.resource_definition).to receive(:canonical_path_action).with(:other_action)
-      Praxis::ActionDefinition.new(:other_action, resource_definition) do
-        canonical_path
-      end
-    end
   end
 end

--- a/spec/praxis/action_definition_spec.rb
+++ b/spec/praxis/action_definition_spec.rb
@@ -21,7 +21,7 @@ describe Praxis::ActionDefinition do
   end
 
   subject(:action) do
-    Praxis::ActionDefinition.new('foo', resource_definition) do
+    Praxis::ActionDefinition.new(:foo, resource_definition) do
       routing { get '/:one' }
       payload { attribute :two, String }
       headers { header "X_REQUESTED_WITH", 'XMLHttpRequest' }

--- a/spec/praxis/action_definition_spec.rb
+++ b/spec/praxis/action_definition_spec.rb
@@ -22,6 +22,7 @@ describe Praxis::ActionDefinition do
 
   subject(:action) do
     Praxis::ActionDefinition.new('foo', resource_definition) do
+      canonical_path
       routing { get '/:one' }
       payload { attribute :two, String }
       headers { header "X_REQUESTED_WITH", 'XMLHttpRequest' }
@@ -30,7 +31,7 @@ describe Praxis::ActionDefinition do
   end
 
   context '#initialize' do
-    its('name')                { should eq 'foo' }
+    its('name')                { should eq :foo }
     its('resource_definition') { should be resource_definition }
     its('params.attributes')   { should have_key :one }
     its('params.attributes')   { should have_key :inherited }
@@ -157,4 +158,12 @@ describe Praxis::ActionDefinition do
 
   end
 
+  context '#canonical_path' do
+    it 'will notify its parent resource_definition with its action name' do
+      expect(action.resource_definition).to receive(:canonical_path_action).with(:other_action)
+      Praxis::ActionDefinition.new(:other_action, resource_definition) do
+        canonical_path
+      end
+    end
+  end
 end

--- a/spec/praxis/resource_definition_spec.rb
+++ b/spec/praxis/resource_definition_spec.rb
@@ -34,6 +34,16 @@ describe Praxis::ResourceDefinition do
       expect(index).to be_kind_of(Praxis::ActionDefinition)
       expect(index.description).to eq("index description")
     end
+    
+    it 'complains if action names are not symbols' do
+      expect do
+        Class.new do
+          include Praxis::ResourceDefinition
+          action "foo" do
+          end
+        end
+      end.to raise_error(ArgumentError,/Action names must be defined using symbols/)
+    end
   end
 
 

--- a/spec/praxis/resource_definition_spec.rb
+++ b/spec/praxis/resource_definition_spec.rb
@@ -113,15 +113,15 @@ describe Praxis::ResourceDefinition do
 
   end
 
-  context '#canonical_path_action' do
+  context '#canonical_path' do
     context 'setting the action' do
       it 'reads the specified action' do
-        expect(subject.canonical_path_action).to eq(subject.actions[:show])
+        expect(subject.canonical_path).to eq(subject.actions[:show])
       end
       it 'cannot be done if already been defined' do
         expect{
-          resource_definition.canonical_path_action :reset
-        }.to raise_error(/Action 'show' has already been selected/)
+          resource_definition.canonical_path :reset
+        }.to raise_error(/'canonical_path' can only be defined once./)
       end
     end  
     context 'if none specified' do
@@ -133,19 +133,19 @@ describe Praxis::ResourceDefinition do
         end
       end
       it 'defaults to the :show action' do
-        expect(subject.canonical_path_action).to eq(subject.actions[:show])        
+        expect(subject.canonical_path).to eq(subject.actions[:show])        
       end
     end
     context 'with an undefined action' do
       subject(:resource_definition) do
         Class.new do
           include Praxis::ResourceDefinition
-          canonical_path_action :non_existent
+          canonical_path :non_existent
         end
       end
       it 'raises an error' do
         expect{
-          subject.canonical_path_action
+          subject.canonical_path
         }.to raise_error(/Action 'non_existent' does not exist/)
       end
     end

--- a/spec/praxis/resource_definition_spec.rb
+++ b/spec/praxis/resource_definition_spec.rb
@@ -113,4 +113,56 @@ describe Praxis::ResourceDefinition do
 
   end
 
+  context '#canonical_path_action' do
+    context 'setting the action' do
+      it 'reads the specified action' do
+        expect(subject.canonical_path_action).to eq(subject.actions[:show])
+      end
+      it 'cannot be done if already been defined' do
+        expect{
+          resource_definition.canonical_path_action :reset
+        }.to raise_error(/Action 'show' has already been selected/)
+      end
+    end  
+    context 'if none specified' do
+      subject(:resource_definition) do
+        Class.new do
+          include Praxis::ResourceDefinition
+          action :show do
+          end
+        end
+      end
+      it 'defaults to the :show action' do
+        expect(subject.canonical_path_action).to eq(subject.actions[:show])        
+      end
+    end
+    context 'with an undefined action' do
+      subject(:resource_definition) do
+        Class.new do
+          include Praxis::ResourceDefinition
+          canonical_path_action :non_existent
+        end
+      end
+      it 'raises an error' do
+        expect{
+          subject.canonical_path_action
+        }.to raise_error(/Action 'non_existent' does not exist/)
+      end
+    end
+  end
+
+  context '#to_href' do
+    it 'accesses the path expansion functions of the primary route' do
+      expect(subject.to_href( id: 1)).to eq("/people/1")
+    end
+  end
+  context '#parse_href' do
+    let(:parsed){ resource_definition.parse_href("/people/1") }
+    it 'accesses the path expansion functions of the primary route' do
+      expect(parsed).to have_key(:id)
+    end
+    it 'coerces the types as specified in the resource definition' do
+      expect(parsed[:id]).to be_kind_of(Integer)
+    end
+  end
 end

--- a/spec/spec_app/app/controllers/instances.rb
+++ b/spec/spec_app/app/controllers/instances.rb
@@ -54,14 +54,14 @@ class Instances < BaseClass
   def bulk_create(cloud_id:)
     self.response = BulkResponse.new
 
+
     request.payload.each do |instance_id,instance|
       part_body = JSON.pretty_generate(key: instance_id, value: instance.render(:create))
       headers = {
         'Status' => '201',
         'Content-Type' => Instance.identifier,
-        'Location' => self.class.definition.actions[:show].primary_route.path.expand(cloud_id: cloud_id, id: instance.id)
+        'Location' => definition.to_href(cloud_id: cloud_id, id: instance.id)
       }
-
       part = Praxis::MultipartPart.new(part_body, headers)
 
       response.add_part(instance_id, part)

--- a/spec/spec_app/design/resources/instances.rb
+++ b/spec/spec_app/design/resources/instances.rb
@@ -4,13 +4,10 @@ module ApiResources
 
     media_type Instance
     version '1.0'
-
-    #responses :instance_limit_reached
-    #responses :pay_us_money
-    #response :create, location: /instances/
-
     
-
+    # The canonical path for the resource can also be defined here, instead of in the action itself:
+    # canonical_path_action :show
+    
     routing do
       prefix '/clouds/:cloud_id/instances'
     end
@@ -44,6 +41,7 @@ module ApiResources
     end
 
     action :show do
+      canonical_path
       routing do
         get '/:id'
         get '/something/:id', name: :alternate

--- a/spec/spec_app/design/resources/instances.rb
+++ b/spec/spec_app/design/resources/instances.rb
@@ -5,8 +5,9 @@ module ApiResources
     media_type Instance
     version '1.0'
     
-    # The canonical path for the resource can also be defined here, instead of in the action itself:
-    # canonical_path_action :show
+    # :show action is the canonical path for this resource.
+    # Note that the following is redundant, since :show is the default canonical path if none is defined.
+    canonical_path :show
     
     routing do
       prefix '/clouds/:cloud_id/instances'
@@ -41,7 +42,6 @@ module ApiResources
     end
 
     action :show do
-      canonical_path
       routing do
         get '/:id'
         get '/something/:id', name: :alternate

--- a/spec/support/spec_resource_definitions.rb
+++ b/spec/support/spec_resource_definitions.rb
@@ -9,6 +9,8 @@ class PeopleResource
 
   version '1.0'
 
+  canonical_path_action :show
+
   routing do
     prefix "/people"
   end

--- a/spec/support/spec_resource_definitions.rb
+++ b/spec/support/spec_resource_definitions.rb
@@ -9,7 +9,7 @@ class PeopleResource
 
   version '1.0'
 
-  canonical_path_action :show
+  canonical_path :show
 
   routing do
     prefix "/people"


### PR DESCRIPTION
Added the definition and handling of canonical urls for API resources
* One can now specify which action URL should be considered as the canonical resource href:
  * by using `canonical_path <action_name>` at the top of the resource definition class
  * See the [instances](https://github.com/rightscale/praxis/blob/master/spec/spec_app/design/resources/instances.rb) resource definition for an example.
* With a canonical href defined, one can then both generate and parse them by using:
  * `.to_href(<named arguments hash>)  =>  <href String>`
  * `.parse_href( <href String> )  => < named arguments hash >`. Note: The returned arguments are properly typed-coerced.
  * These helpers can be accessed from:
    * the `definition` object in the controller instance (i.e., `self.definition.to_href(id: 1). )
    * or through the class-level methods in the resource definition (i.e. `MyApiResource.parse_href("/my_resource/1")` )
