### PR TITLE
Hooked up rake tasks into the `praxis` binary for convenience.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
     * These helpers can be accessed from:
       * the `definition` object in the controller instance (i.e., `self.definition.to_href(id: 1). )
       * or through the class-level methods in the resource definition (i.e. `MyApiResource.parse_href("/my_resource/1")` )
+* Hooked up rake tasks into the `praxis` binary for convenience. In particular 
+  * praxis routes [json]
+  * praxis docs [browser]
+  * praxis console 
+ 
 
 ## 0.13.0
 

--- a/bin/praxis
+++ b/bin/praxis
@@ -2,12 +2,46 @@
 
 require 'bundler'
 
+Bundler.setup :default, :test
+Bundler.require :default, :test
+
+
+if ["routes","docs","console"].include? ARGV[0]
+  require 'rake'
+  require 'praxis'
+  require 'praxis/tasks'
+  
+  case ARGV[0]
+    when "routes"
+      Rake::Task['praxis:routes'].invoke(ARGV[1])
+    when "docs"
+      task_name = ARGV[1] == 'browser' ? 'praxis:doc_browser' : 'praxis:api_docs' 
+      Rake::Task[task_name].invoke
+    when "console"
+      Rake::Task['praxis:console'].invoke
+  end
+  exit 0
+end
+# Thor tasks
 path_to_praxis = File.expand_path(File.dirname(File.dirname(__FILE__)))
 path_to_loader = '%s/tasks/loader.thor' % path_to_praxis
 
 load path_to_loader
 
 class PraxisGenerator < Thor
+  
+  # Include a few fake thor action descriptions (for the rake tasks above) so they can show up in the same usage messages
+  desc "routes [json]", "Prints the route table of the application. Defaults to table format, but can produce json"
+  def routes
+  end
+
+  desc "docs [browser]", "Generates API JSON documents. Automatically starts a Web bowser with 'browser' parameter"
+  def docs
+  end
+  
+  desc "console", "Open a console to the application, with its environment loaded"
+  def console
+  end
 
   # Simple helper to go get the existing description for the real action
   # Usage must still be provided rather than retrieved (since it is not a 
@@ -33,7 +67,7 @@ class PraxisGenerator < Thor
   def generate(app_name)
     warn "This is a deprecated method.\nTo generate a hello world example, please use:\n  praxis example #{app_name} "
   end
+  
 end
-
-
+    
 PraxisGenerator.start(ARGV)


### PR DESCRIPTION
In particular added: 
  * praxis routes [json] 
  * praxis docs [browser] 
  * praxis console 

Also made both Thor generators and rake tasks to use a common usage message.

```
Commands:
  praxis console            # Open a console to the application, with its environment loaded
  praxis docs [browser]     # Generates API JSON documents. Automatically starts a Web bowser with 'browser' parameter
  praxis example APP_NAME   # Generates a new 'hello world' example application under an <app_name> directory
  praxis generate APP_NAME  # DEPRECATED!: Generates a new 'hello world' example application under an <app_name> directory
  praxis help [COMMAND]     # Describe available commands or one specific command
  praxis new APP_NAME       # Generates a blank new app under <app_name> (with a full skeleton ready to start coding)
  praxis routes [json]      # Prints the route table of the application. Defaults to table format, but can produce json
```

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>