### PR TITLE
Improved code for stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,10 @@
 * Fixed `ResponseDefinition` Content-Type validation to properly handle parameters (i.e., "application/json;collection=true").
   * Note: For "index" type actions, this now means Praxis will properly validate any 'collection=true' parameter specified in the `ResponseDefintion` and set by the controller.
 * Deprecated `MediaTypeCollection`. Please define separate classes and attributes for "collection" and "summary" uses.
-
-
+* Improved code for stages 
+  * `setup!` is no longer called within the `run` default code of a stage 
+  * removed unnecessary raise error when substages are empty (while not common it can be possible, and totally valid)
+   
 ## 0.13.0
 * Added `nodoc!` method to `ActionDefinition`, `ResourceDefinition` to hide actions and resources from the generated documentation.
 * Default HTTP responses:

--- a/lib/praxis/bootloader.rb
+++ b/lib/praxis/bootloader.rb
@@ -114,6 +114,7 @@ module Praxis
 
     def run
       stages.each do |stage|
+        stage.setup!
         stage.run
       end
     end

--- a/lib/praxis/resource_definition.rb
+++ b/lib/praxis/resource_definition.rb
@@ -42,10 +42,10 @@ module Praxis
         @media_type = media_type
       end
 
-      def version(version=nil, options= { using: [:header,:params] }.freeze )
+      def version(version=nil, options=nil)
         return @version unless version
         @version = version
-        @version_options = options
+        @version_options = options || {using: [:header,:params]}.freeze
       end
 
       def canonical_path( action_name=nil )

--- a/lib/praxis/stage.rb
+++ b/lib/praxis/stage.rb
@@ -24,14 +24,13 @@ module Praxis
     end
 
     def run
-      setup!
-      setup_deferred_callbacks!
       execute_callbacks(self.before_callbacks)
       execute
       execute_callbacks(self.after_callbacks)
     end
 
     def setup!
+      setup_deferred_callbacks!
     end
 
     def setup_deferred_callbacks!
@@ -48,8 +47,6 @@ module Praxis
     end
 
     def execute
-      raise NotImplementedError, 'Subclass must implement Stage#execute' unless @stages.any?
-
       @stages.each do |stage|
         stage.run
       end

--- a/spec/praxis/bootloader_spec.rb
+++ b/spec/praxis/bootloader_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Praxis::Bootloader do
   let(:application) do
-    instance_double("Praxis::Application", config: "config", root: "root", plugins: {})
+    instance_double("Praxis::Application", config: "config", root: "root", plugins: {}, file_layout: {} )
   end
 
   subject(:bootloader) {Praxis::Bootloader.new(application)}
@@ -17,6 +17,15 @@ describe Praxis::Bootloader do
     its(:root) {should be(application.root)}
   end
 
+  context ".run" do
+    it "should call setup and run for all the stages" do
+      bootloader.stages.each do |s|
+        expect(s).to receive(:setup!).once
+        expect(s).to receive(:run).once
+      end
+      bootloader.run
+    end
+  end
   context ".delete_stage" do
     it "delete valid stage" do
       bootloader.delete_stage(:app)

--- a/spec/praxis/stage_spec.rb
+++ b/spec/praxis/stage_spec.rb
@@ -13,8 +13,6 @@ describe Praxis::Stage do
 
   context ".run" do
     it "sets up and execute callbacks" do
-      expect(stage).to receive('setup!')
-      expect(stage).to receive('setup_deferred_callbacks!')
       expect(stage).to receive('execute')
       expect(stage).to receive('execute_callbacks').twice
       stage.run
@@ -22,7 +20,10 @@ describe Praxis::Stage do
   end
 
   context ".setup!" do
-    it "should do something"
+    it 'should call setup_deferred_callbacks' do
+      expect(stage).to receive('setup_deferred_callbacks!')
+      stage.setup!
+    end
   end
 
   context ".setup_deferred_callbacks!" do
@@ -40,11 +41,6 @@ describe Praxis::Stage do
   end
 
   context ".execute" do
-    it "raises error when @stages is empty" do
-      error_msg = 'Subclass must implement Stage#execute'
-      expect{stage.execute}.to raise_error(NotImplementedError, error_msg)
-    end
-
     it "runs all the stages" do
       double_stage = double("stage")
       expect(double_stage).to receive('run')


### PR DESCRIPTION
* `setup!` is no longer called within the `run` default code of a stage 
* removed unnecessary raise error when substages are empty (while not common it can be possible, and totally valid)

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>