### PR TITLE
Doc browser rake cleanup

### DIFF
--- a/lib/praxis/tasks/api_docs.rb
+++ b/lib/praxis/tasks/api_docs.rb
@@ -9,20 +9,21 @@ namespace :praxis do
         raise Exception.new("NPM Install Failed")
       end
 
-      docs_dir=File.join(Dir.pwd, 'docs')
+      docs_dir = File.join(Dir.pwd, 'docs')
       FileUtils.mkdir_p docs_dir unless File.directory? docs_dir
 
       # The doc browser will need to have a minimal app.js and styles.css file at the root
-      # Let's add them if the app has not overriden them 
-      js_file = File.join(Dir.pwd, 'docs', 'app.js') 
-      scss_file = File.join(Dir.pwd, 'docs', 'styles.scss')   
+      # Let's add them if the app has not overriden them
+      js_file = File.join(Dir.pwd, 'docs', 'app.js')
+      scss_file = File.join(Dir.pwd, 'docs', 'styles.scss')
+      template_directory = File.expand_path(File.join(File.dirname(__FILE__), '../../../tasks/thor/templates/generator/empty_app/docs'))
+
       unless File.exists? js_file
-        File.open(js_file, 'w') {|f| f.write(%q{angular.module('DocBrowser', ['PraxisDocBrowser']);}) }
+        FileUtils.cp File.join(template_directory, 'app.js'), js_file
       end
       unless File.exists? scss_file
-        File.open(scss_file, 'w') {|f| f.write(%q{@import "praxis.scss";}) }
+        FileUtils.cp File.join(template_directory, 'styles.scss'), scss_file
       end
-
     end
 
     desc "Run API Documentation Browser"
@@ -46,26 +47,15 @@ namespace :praxis do
   end
 
   desc "Generate API docs (JSON definitions) for a Praxis App"
-  task :api_docs => ['docs:generate']
+  task :api_docs do
+    STDERR.puts "DEPRECATION: praxis:api_docs is deprecated and will be removed by 1.0. Please use praxis:docs:generate instead."
+    Rake::Task["praxis:docs:generate"].invoke
+  end
 
   desc "Run API Documentation Browser"
-  task :doc_browser, [:port] => :api_docs do |t, args|
-    args.with_defaults port: 4567
-
-    public_folder =  File.expand_path("../../../", __FILE__) + "/api_browser/app"
-    app = Rack::Builder.new do
-      map "/docs" do # application JSON docs
-        use Rack::Static, urls: [""], root: File.join(Dir.pwd, Praxis::RestfulDocGenerator::API_DOCS_DIRNAME)
-      end
-      map "/" do # Assets mapping
-        use Rack::Static, urls: [""], root: public_folder, index: "index.html"
-      end
-
-      run lambda { |env| [404, {'Content-Type' => 'text/plain'}, ['Not Found']] }
-    end
-
-
-    Rack::Server.start app: app, Port: args[:port]
+  task :doc_browser, [:port] do |t, args|
+    STDERR.puts "DEPRECATION: praxis:doc_browser is deprecated and will be removed by 1.0. Please use praxis:docs:preview instead. The doc browser now runs on port 9090."
+    Rake::Task["praxis:docs:preview"].invoke
   end
 
 end


### PR DESCRIPTION
Adds deprecation notices and cleans up upgrade path (so now if we changes the default layout of those files, they should be generated correctly).

We ran into this when upgrading to master, my colleagues tried running `rake praxis:doc_browser` and then complained that this praxis is broken.