### PR TITLE
Enhances the praxis:docs:preview with an optional port parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * Fix doc generation to use `ids` for top-level types (rather than names) so they are correctly linkable.
 * Doc Browser: Added support for Markdown rendering of descriptions (for resources, media_types, attributes, etc...)
 * Added test framework for the doc browser. Run the tests with `grunt test` from lib/api_browser.
+* Enhanced the `praxis:docs:preview` rake task with an optional port parameter
 
 ## 0.13.0
 * Added `nodoc!` method to `ActionDefinition`, `ResourceDefinition` to hide actions and resources from the generated documentation.

--- a/lib/api_browser/Gruntfile.js
+++ b/lib/api_browser/Gruntfile.js
@@ -10,7 +10,8 @@ module.exports = function(grunt) {
   }
 
   var userDocsPath = process.env.USER_DOCS_PATH,
-      buildPath    = userDocsPath + '/output';
+      buildPath    = userDocsPath + '/output',
+      browserPort  = process.env.DOC_PORT || '9090';
 
   var cssOutput = {};
   cssOutput[buildPath + '/css/main.css'] = userDocsPath + '/styles.scss';
@@ -19,7 +20,7 @@ module.exports = function(grunt) {
     // web server for development
     connect: {
       options: {
-        port: '9090',
+        port: browserPort,
         hostname: '0.0.0.0'
       },
       livereload: {

--- a/lib/praxis/tasks/api_docs.rb
+++ b/lib/praxis/tasks/api_docs.rb
@@ -27,13 +27,13 @@ namespace :praxis do
     end
 
     desc "Run API Documentation Browser"
-    task :preview, [:port] => [:install, 'docs:generate']  do |t, args|      
+    task :preview, [:port] => [:install, :generate]  do |t, args|      
       doc_port = args[:port] || '9090'
       exec({'USER_DOCS_PATH' => File.join(Dir.pwd, 'docs'), 'DOC_PORT' => doc_port}, "#{path}/node_modules/.bin/grunt serve --gruntfile '#{path}/Gruntfile.js'")
     end
 
     desc "Build docs that can be shipped"
-    task :build => [:install, 'docs:generate'] do
+    task :build => [:install, :generate] do
       exec({'USER_DOCS_PATH' => File.join(Dir.pwd, 'docs')}, "#{path}/node_modules/.bin/grunt build --gruntfile '#{path}/Gruntfile.js'")
     end
 

--- a/lib/praxis/tasks/api_docs.rb
+++ b/lib/praxis/tasks/api_docs.rb
@@ -27,8 +27,9 @@ namespace :praxis do
     end
 
     desc "Run API Documentation Browser"
-    task :preview => [:install, 'docs:generate'] do
-      exec({'USER_DOCS_PATH' => File.join(Dir.pwd, 'docs')}, "#{path}/node_modules/.bin/grunt serve --gruntfile '#{path}/Gruntfile.js'")
+    task :preview, [:port] => [:install, 'docs:generate']  do |t, args|      
+      doc_port = args[:port] || '9090'
+      exec({'USER_DOCS_PATH' => File.join(Dir.pwd, 'docs'), 'DOC_PORT' => doc_port}, "#{path}/node_modules/.bin/grunt serve --gruntfile '#{path}/Gruntfile.js'")
     end
 
     desc "Build docs that can be shipped"


### PR DESCRIPTION
* `rake praxis:docs:preview[4567]` will now launch the server on port 4567 (instead of the 9090 default)

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>