### PR TITLE
Update grunt-sass

### DIFF
--- a/lib/api_browser/package.json
+++ b/lib/api_browser/package.json
@@ -23,7 +23,7 @@
     "grunt-file-blocks": "^0.3.0",
     "grunt-filerev": "^0.2.1",
     "grunt-ngmin": "0.0.3",
-    "grunt-sass": "^0.17.0",
+    "grunt-sass": "^0.18.0",
     "grunt-usemin": "^2.1.1",
     "grunt-wiredep": "^1.7.0",
     "load-grunt-tasks": "^0.4.0"


### PR DESCRIPTION
Fixes #147.

```
$ rm -r node_modules/
$ node -v
v0.12.0
$ npm install
# succeeds
```

```
$ rm -r node_modules/
$ nvm use v0.10.25
Now using node v0.10.25
$ node -v
v0.10.25
$ npm install
# succeeds
```