### PR TITLE
Improve type inheritance for `link` method with `:using` option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## next
 
+* Improved `link` method in `MediaType` attribute definition to support inheriting the type from the `:using` option if if that specifies an attribute. For example: `link :posts, using: :posts_summary` would use the type of the `:posts_summary` attribute.
+
 ## 0.14.0 
 
 * Adds features for customizing and exporting the Doc browser, namely the following changes:

--- a/lib/praxis/links.rb
+++ b/lib/praxis/links.rb
@@ -13,6 +13,9 @@ module Praxis
 
       def link(name, type=nil, using: name, **opts, &block)
         links[name] = using
+        if type.nil? && (name != using)
+          type = options[:reference].attributes[using].type
+        end
         attribute(name, type, **opts, &block)
       end
     end

--- a/spec/praxis/media_type_spec.rb
+++ b/spec/praxis/media_type_spec.rb
@@ -3,9 +3,10 @@ require 'spec_helper'
 describe Praxis::MediaType do
   let(:owner_resource) { instance_double(Person, id: 100, name: /[:name:]/.gen, href: '/', links: ['one','two']) }
   let(:manager_resource) { instance_double(Person, id: 101, name: /[:name:]/.gen, href: '/', links: []) }
+  let(:custodian_resource) { instance_double(Person, id: 102, name: /[:name:]/.gen, href: '/', links: []) }
 
   let(:resource) do
-    double('address', id: 1, name: 'Home',owner: owner_resource, manager: manager_resource)
+    double('address', id: 1, name: 'Home',owner: owner_resource, manager: manager_resource, custodian: custodian_resource)
   end
 
   subject(:address) { Address.new(resource) }
@@ -20,7 +21,9 @@ describe Praxis::MediaType do
       it 'respects using' do
         expect(address.links.super).to be_kind_of(Person)
         expect(address.links.super.object).to be(resource.manager)
+        expect(address.links.caretaker.object).to be(resource.custodian)
       end
+
     end
   end
 
@@ -43,6 +46,13 @@ describe Praxis::MediaType do
       context 'using the links DSL' do
         subject(:address) { Address.new(resource) }
         its(:links)  { should be_kind_of(Address::Links) }
+
+        it 'inherits types appropriately' do
+          links_attribute = Address::Links.attributes
+          expect(links_attribute[:owner].type).to be(Person)
+          expect(links_attribute[:super].type).to be(Person)
+          expect(links_attribute[:caretaker].type).to be(Person)
+        end
       end
       
     end

--- a/spec/support/spec_media_types.rb
+++ b/spec/support/spec_media_types.rb
@@ -30,10 +30,12 @@ class Address < Praxis::MediaType
     attribute :name, String
 
     attribute :owner, Person
-
+    attribute :custodian, Person
+    
     links do
       link :owner
       link :super, Person, using: :manager
+      link :caretaker, using: :custodian
     end
 
   end


### PR DESCRIPTION
Signed-off-by: Dane Jensen <dane@rightscale.com>