### PR TITLE
Add warning message for doc gen task. Fixes #151.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## next
 
+* Handled and added warning message for doc generation task when no routing block is defined for an action.  
 * Improved `link` method in `MediaType` attribute definition to support inheriting the type from the `:using` option if if that specifies an attribute. For example: `link :posts, using: :posts_summary` would use the type of the `:posts_summary` attribute.
 
 ## 0.14.0 

--- a/lib/praxis/action_definition.rb
+++ b/lib/praxis/action_definition.rb
@@ -173,10 +173,15 @@ module Praxis
     end
 
     def params_description
-      route_params = primary_route.path.
-        named_captures.
-        keys.
-        collect(&:to_sym)
+      route_params = []
+      if primary_route.nil?
+        warn "Warning: No routes defined for #{resource_definition.name}##{name}."
+      else
+        route_params = primary_route.path.
+          named_captures.
+          keys.
+          collect(&:to_sym)
+      end
 
       desc = params.describe
       desc[:type][:attributes].keys.each do |k|
@@ -185,7 +190,7 @@ module Praxis
         else
           'query'
         end
-        desc[:type][:attributes][k][:source] = source          
+        desc[:type][:attributes][k][:source] = source
       end
       desc
     end


### PR DESCRIPTION
When action missing routing block, praxis:docs:generate would crash. Now generation continues
with warning message printed.

Signed-off-by: Michelle Sausa <michelle@rightscale.com>