### PR TITLE
Response examples

### DIFF
--- a/lib/api_browser/Gruntfile.js
+++ b/lib/api_browser/Gruntfile.js
@@ -319,7 +319,7 @@ module.exports = function(grunt) {
         // Updates index.html for any file added or removed
         scripts: {
           files: ['app/js/**/*.js', userDocsPath + '/**/*.js'],
-          tasks: 'fileblocks:serve',
+          tasks: ['fileblocks:serve', 'wiredep'],
           options: { livereload: 9091 }
         },
 

--- a/lib/api_browser/app/index.html
+++ b/lib/api_browser/app/index.html
@@ -14,35 +14,8 @@
   <div ui-view=""></div>
   <!-- build:js({.tmp,app}) scripts/praxis.js -->
   <!-- bower:js -->
-  <script src="bower_components/jquery/dist/jquery.js"></script>
-  <script src="bower_components/angular/angular.js"></script>
-  <script src="bower_components/lodash/dist/lodash.compat.js"></script>
-  <script src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
-  <script src="bower_components/angular-ui-bootstrap-bower/ui-bootstrap-tpls.js"></script>
-  <script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
   <!-- endbower -->
   <!-- fileblock:js scripts -->
-  <script src="js/app.js"></script>
-  <script src="js/filters/resource_name.js"></script>
-  <script src="js/controllers/menu.js"></script>
-  <script src="js/controllers/action.js"></script>
-  <script src="js/directives/attribute_table.js"></script>
-  <script src="js/controllers/type.js"></script>
-  <script src="js/controllers/controller.js"></script>
-  <script src="js/factories/Documentation.js"></script>
-  <script src="js/directives/type_label.js"></script>
-  <script src="js/filters/attribute_name.js"></script>
-  <script src="js/filters/friendly_json.js"></script>
-  <script src="js/directives/attribute_description.js"></script>
-  <script src="js/directives/attribute_table_row.js"></script>
-  <script src="js/factories/TypeTemplates.js"></script>
-  <script src="js/directives/no_container.js"></script>
-  <script src="js/filters/is_empty.js"></script>
-  <script src="js/directives/request_body.js"></script>
-  <script src="js/factories/PayloadTemplates.js"></script>
-  <script src="js/factories/TemplateProvider.js"></script>
-  <script src="js/directives/request_headers.js"></script>
-  <script src="js/directives/request_parameters.js"></script>
   <!-- endfileblock -->
   <!-- endbuild -->
   <!-- build:js({/,.tmp}) scripts/docs.js -->

--- a/lib/api_browser/app/js/controllers/action.js
+++ b/lib/api_browser/app/js/controllers/action.js
@@ -4,6 +4,8 @@ app.controller('ActionCtrl', function($scope, $stateParams, Documentation) {
   $scope.apiVersion = $stateParams.version;
 
   Documentation.getController($stateParams.version, $stateParams.controller).then(function(response) {
+    var responsesWithTypes;
+
     $scope.action = _.find(response.data.actions, function(action) { return action.name === $scope.actionName; });
     if (!$scope.action) {
       $scope.error = true;
@@ -41,6 +43,14 @@ app.controller('ActionCtrl', function($scope, $stateParams, Documentation) {
       }
     });
 
+    responsesWithTypes = _($scope.responses).map('media_type').compact().value();
+
+    // Only one response has a media type, so we can show it.
+    if (responsesWithTypes) {
+      Documentation.getType($stateParams.version, responsesWithTypes[0].id).then(function(response) {
+        $scope.example_response = response.data.example;
+      });
+    }
   }, function() {
     $scope.error = true;
   });

--- a/lib/api_browser/app/views/action.html
+++ b/lib/api_browser/app/views/action.html
@@ -77,5 +77,10 @@
         </table>
       </div>
     </div>
+
+    <div ng-if="example_response" class="col-lg-12">
+      <h3>Example response</h3>
+      <pre>{{example_response | friendlyJson}}</pre>
+    </div>
   </div>
 </div>

--- a/lib/api_browser/app/views/action.html
+++ b/lib/api_browser/app/views/action.html
@@ -65,7 +65,9 @@
                 {{response.name}}
               </td>
               <td>
-                {{response.media_type.id || response.media_type.identifier}}
+                <a ui-sref="root.type({version: apiVersion, type: response.media_type.id })">
+                  {{response.media_type.name || response.media_type.identifier}}
+                </a>
               </td>
               <td>
                 <rs-attribute-description attribute="response"></rs-attribute-description>


### PR DESCRIPTION
This shows the example response for an action if the action only has one media type in its responses, and also links to the media type from the responses list.

![image](https://cloud.githubusercontent.com/assets/1120328/6757205/2eeb99ce-cf27-11e4-9d06-1e0c3df91112.png)
