### PR TITLE
Allow passing options to Mustermann

### DIFF
--- a/lib/praxis/skeletor/restful_routing_config.rb
+++ b/lib/praxis/skeletor/restful_routing_config.rb
@@ -39,7 +39,7 @@ module Praxis
       def trace(path, opts={})   add_route 'TRACE',   path, opts end
       def connect(path, opts={}) add_route 'CONNECT', path, opts end
       def patch(path, opts={})   add_route 'PATCH',   path, opts end
-      def any(path, opts={})     add_route 'ANY',       path, opts end
+      def any(path, opts={})     add_route 'ANY',     path, opts end
 
         
 

--- a/lib/praxis/skeletor/restful_routing_config.rb
+++ b/lib/praxis/skeletor/restful_routing_config.rb
@@ -44,7 +44,8 @@ module Praxis
         
 
       def add_route(verb, path, options={})
-        path = Mustermann.new(prefix + path)
+        mustermann_options = options.delete(:mustermann_options)
+        path = Mustermann.new(prefix + path, mustermann_options || {})
 
         @routes << Route.new(verb, path, resource_definition.version, **options)
       end


### PR DESCRIPTION
This lets you do:

```ruby
routing do
  get '/*', mustermann_options: {except: '/login'}
end
```

and have it work as expected. The only option (here's the [list of options](https://github.com/rkh/mustermann/tree/master/mustermann/#-sinatra-pattern)) I can see being particularly useful in this context is [`except`](https://github.com/rkh/mustermann/tree/master/mustermann/#-available-options--except), so I'm also tempted to just allow that as its own, explicit option, but I figured this was more straightforward for now.