### PR TITLE
170 stack recursion rendering docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   * *Note*: this may break some existing trait use cases, as they are now more-defined in their behavior, rather than simply stored blocks that are `instance_eval`-ed on the target.
 * Deprecated `ResourceDefinition.routing`. Use `ResourceDefinition.prefix` to define resource-level route prefixes instead.
 * Significantly refactored route generation.
-  * The `base_path` property defined in `ApiDefinition#info` will now appear in the routing paths 'base' (instead of simply being used for documentation purposes). 
+  * The `base_path` property defined in `ApiDefinition#info` will now appear in the routing paths 'base' (instead of simply being used for documentation purposes).
     *Note*: unlike other info at that level, a global (unversioned) `base_path` is *not* overriden by specific version, rather the specific version's path is appended to the global path.
   * Any prefixes set on a `ResourceDefinition` or inside a `routing` block of an ActionDefinition are now additive. For example:
     * Setting a "/myresource" prefix in a "MyResource" definition, and setting a "/myaction" prefix within an action of that resource definition will result in a route containing the following segments ".../myresource/myaction...".
@@ -19,19 +19,19 @@
 * Added `base_params` to `ApiDefinition#info` as a way to share common action params
   * `base_params` may be defined for a specific Api version, which will make sharing params across all Resource definitions of that version)
   * or `base_params` may be defined in the Global Api section, which will make the parameters shared across all actions of all defined Api versions.
-
+* Fixed `MediaType#describe` to include the correct string representation of its identifier.
 
 ## 0.15.0
 
 * Fixed handling of no app or design file groups defined in application layout.
-* Handled and added warning message for doc generation task when no routing block is defined for an action.  
+* Handled and added warning message for doc generation task when no routing block is defined for an action.
 * Improved `link` method in `MediaType` attribute definition to support inheriting the type from the `:using` option if if that specifies an attribute. For example: `link :posts, using: :posts_summary` would use the type of the `:posts_summary` attribute.
 * Fixed generated `Links` accessors to properly load the returned value.
 * Added `MediaTypeIdentifier` class to parse and manipulate Content-Type headers and Praxis::MediaType identifiers.
 * Created a registry for media type handlers that parse and generate document bodies with formats other than JSON.
   * Given a structured-data response, Praxis will convert it to JSON, XML or other formats based on the handler indicated by its Content-Type.
   * Given a request, Praxis will use the handler indicated by its Content-Type header to parse the body into structured data.
-* Fixed bug allowing "praxis new" to work when Praxis is installed as a system (non-bundled) gem. 
+* Fixed bug allowing "praxis new" to work when Praxis is installed as a system (non-bundled) gem.
 * Fixed doc generation code for custom types
 * Hardened Multipart type loading
 

--- a/lib/praxis/types/media_type_common.rb
+++ b/lib/praxis/types/media_type_common.rb
@@ -9,7 +9,7 @@ module Praxis
         def describe(shallow = false)
           hash = super
           unless shallow
-            hash.merge!(identifier: @identifier, description: @description)
+            hash.merge!(identifier: @identifier.to_s, description: @description)
           end
           hash
         end

--- a/spec/praxis/media_type_spec.rb
+++ b/spec/praxis/media_type_spec.rb
@@ -9,8 +9,8 @@ describe Praxis::MediaType do
   end
 
   let(:resource) do
-    double('address', 
-      id: 1, 
+    double('address',
+      id: 1,
       name: 'Home',
       owner: owner_resource,
       manager: manager_resource,
@@ -38,7 +38,7 @@ describe Praxis::MediaType do
   end
 
 
-  
+
   context 'accessor methods' do
     subject(:address_klass) { address.class }
 
@@ -62,7 +62,7 @@ describe Praxis::MediaType do
     end
 
     its(:description) { should be_kind_of(String) }
-    
+
     context 'links' do
       context 'with a custom links attribute' do
         subject(:person) { Person.new(owner_resource) }
@@ -70,7 +70,7 @@ describe Praxis::MediaType do
         its(:links)  { should be_kind_of(Array) }
         its(:links)  { should eq(owner_resource.links) }
       end
-  
+
       context 'using the links DSL' do
         subject(:address) { Address.new(resource) }
         its(:links)  { should be_kind_of(Address::Links) }
@@ -114,7 +114,7 @@ describe Praxis::MediaType do
         let(:snapshots_summary) { volume.snapshots_summary }
         let(:output) { volume.render(:default) }
         subject { links[:snapshots] }
-             
+
         its([:name]) { should eq(snapshots_summary.name) }
         its([:size]) { should eq(snapshots_summary.size) }
         its([:href]) { should eq(snapshots_summary.href) }
@@ -139,6 +139,33 @@ describe Praxis::MediaType do
     end
   end
 
+
+  context 'describing' do
+
+    subject(:described){ Address.describe }
+
+    its(:keys) { should match_array( [:attributes, :description, :family, :id, :identifier, :key, :name, :views] ) }
+    its([:attributes]) { should be_kind_of(::Hash) }
+    its([:description]) { should be_kind_of(::String) }
+    its([:family]) { should be_kind_of(::String) }
+    its([:id]) { should be_kind_of(::String) }
+    its([:name]) { should be_kind_of(::String) }
+    its([:identifier]) { should be_kind_of(::String) }
+    its([:key]) { should be_kind_of(::Hash) }
+    its([:views]) { should be_kind_of(::Hash) }
+
+    its([:description]) { should eq(Address.description) }
+    its([:family]) { should eq(Address.family) }
+    its([:id]) { should eq(Address.id) }
+    its([:name]) { should eq(Address.name) }
+    its([:identifier]) { should eq(Address.identifier.to_s) }
+    it 'should include the defined views' do
+      expect( subject[:views].keys ).to match( [:default, :master] )
+    end
+    it 'should include the defined attributes' do
+      expect( subject[:attributes].keys ).to match( [:id, :name, :owner, :custodian, :residents, :residents_summary, :links] )
+    end
+  end
 
   context 'using blueprint caching' do
     it 'has specs'


### PR DESCRIPTION
Fixed `MediaType#describe` to include the correct string representation of its identifier.