### PR TITLE
Allow native routing options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
   * `base_params` may be defined for a specific Api version, which will make sharing params across all Resource definitions of that version)
   * or `base_params` may be defined in the Global Api section, which will make the parameters shared across all actions of all defined Api versions.
 * Fixed `MediaType#describe` to include the correct string representation of its identifier.
+* Allow route options to be passed to the underlying router (i.e. Mustermann at the moment)
+  * routes defined in the `routing` blocks can now take any extra options which will be passed down to the Mustermann routing engine. Unknown options will be ignored!
+  * Displaying routes (`praxis routes` or `rake praxis:routes`) will now include any options defined in a route.
+  * Added an example on the instances resource of the embedded spec_app to show how to use the advanced `*` pattern and the `:except` Mustermann options (along with the required `:splat` attribute).
+
+
 
 ## 0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   * *Note*: this may break some existing trait use cases, as they are now more-defined in their behavior, rather than simply stored blocks that are `instance_eval`-ed on the target.
 * Deprecated `ResourceDefinition.routing`. Use `ResourceDefinition.prefix` to define resource-level route prefixes instead.
 * Significantly refactored route generation.
-  * The `base_path` property defined in `ApiDefinition#info` will now appear in the routing paths 'base' (instead of simply being used for documentation purposes). 
+  * The `base_path` property defined in `ApiDefinition#info` will now appear in the routing paths 'base' (instead of simply being used for documentation purposes).
     *Note*: unlike other info at that level, a global (unversioned) `base_path` is *not* overriden by specific version, rather the specific version's path is appended to the global path.
   * Any prefixes set on a `ResourceDefinition` or inside a `routing` block of an ActionDefinition are now additive. For example:
     * Setting a "/myresource" prefix in a "MyResource" definition, and setting a "/myaction" prefix within an action of that resource definition will result in a route containing the following segments ".../myresource/myaction...".
@@ -19,19 +19,19 @@
 * Added `base_params` to `ApiDefinition#info` as a way to share common action params
   * `base_params` may be defined for a specific Api version, which will make sharing params across all Resource definitions of that version)
   * or `base_params` may be defined in the Global Api section, which will make the parameters shared across all actions of all defined Api versions.
-
+* Fixed `MediaType#describe` to include the correct string representation of its identifier.
 
 ## 0.15.0
 
 * Fixed handling of no app or design file groups defined in application layout.
-* Handled and added warning message for doc generation task when no routing block is defined for an action.  
+* Handled and added warning message for doc generation task when no routing block is defined for an action.
 * Improved `link` method in `MediaType` attribute definition to support inheriting the type from the `:using` option if if that specifies an attribute. For example: `link :posts, using: :posts_summary` would use the type of the `:posts_summary` attribute.
 * Fixed generated `Links` accessors to properly load the returned value.
 * Added `MediaTypeIdentifier` class to parse and manipulate Content-Type headers and Praxis::MediaType identifiers.
 * Created a registry for media type handlers that parse and generate document bodies with formats other than JSON.
   * Given a structured-data response, Praxis will convert it to JSON, XML or other formats based on the handler indicated by its Content-Type.
   * Given a request, Praxis will use the handler indicated by its Content-Type header to parse the body into structured data.
-* Fixed bug allowing "praxis new" to work when Praxis is installed as a system (non-bundled) gem. 
+* Fixed bug allowing "praxis new" to work when Praxis is installed as a system (non-bundled) gem.
 * Fixed doc generation code for custom types
 * Hardened Multipart type loading
 

--- a/lib/praxis/router.rb
+++ b/lib/praxis/router.rb
@@ -11,7 +11,7 @@ module Praxis
         @version = version
       end
       def call(request)
-        if request.version(@target.action.resource_definition.version_options) == @version          
+        if request.version(@target.action.resource_definition.version_options) == @version
           @target.call(request)
         else
           # Version doesn't match, pass and continue
@@ -20,8 +20,8 @@ module Praxis
         end
       end
     end
-    
-    class RequestRouter < Mustermann::Router::Simple      
+
+    class RequestRouter < Mustermann::Router::Simple
       def initialize(default: nil, **options, &block)
         options[:default] = :not_found
 
@@ -48,8 +48,7 @@ module Praxis
     end
 
     def add_route(target, route)
-      warn 'other conditions not supported yet' if route.options.any?
-      version_wrapper = VersionMatcher.new(target, version: route.version)    
+      version_wrapper = VersionMatcher.new(target, version: route.version)
       @routes[route.verb].on(route.path, call: version_wrapper)
     end
 
@@ -75,17 +74,17 @@ module Praxis
            :not_found
          end
       end
-      
+
       if result == :not_found
         # no need to try :path as we cannot really know if you've attempted to pass a version through it here
         # plus we wouldn't have tracked it as unmatched
-        version = request.version(using: [:header,:params]) 
+        version = request.version(using: [:header,:params])
         attempted_versions = request.unmatched_versions
         body = "NotFound"
         unless attempted_versions.empty? || (attempted_versions.size == 1 && attempted_versions.first == 'n/a')
-          body += if version == 'n/a' 
-                    ". Your request did not specify an API version.".freeze 
-                  else 
+          body += if version == 'n/a'
+                    ". Your request did not specify an API version.".freeze
+                  else
                     ". Your request speficied API version = \"#{version}\"."
                   end
           pretty_versions = attempted_versions.collect(&:inspect).join(', ')
@@ -95,7 +94,7 @@ module Praxis
         if Praxis::Application.instance.config.praxis.x_cascade
           headers['X-Cascade'] = 'pass'
         end
-        result = [404, headers, [body]] 
+        result = [404, headers, [body]]
       end
       result
     end

--- a/lib/praxis/routing_config.rb
+++ b/lib/praxis/routing_config.rb
@@ -9,7 +9,7 @@ module Praxis
       @version = version
       @base = base
       @prefix_segments = Array(prefix)
-      
+
       @routes = []
 
       if block_given?
@@ -49,11 +49,14 @@ module Praxis
 
     def add_route(verb, path, options={})
       unless path =~ ABSOLUTE_PATH_REGEX
-        path = prefix + path        
+        path = prefix + path
       end
 
       path = (base + path).gsub('//','/')
-      pattern = Mustermann.new(path)
+      mustermann_options = {ignore_unknown_options: true}
+      # Reject our own options
+      possible_mustermann_options = options.reject{|(k,_)| [:name].include?(k) }
+      pattern = Mustermann.new(path, mustermann_options.merge( possible_mustermann_options ))
       route = Route.new(verb, pattern, version, **options)
       @routes << route
       route

--- a/lib/praxis/routing_config.rb
+++ b/lib/praxis/routing_config.rb
@@ -53,11 +53,10 @@ module Praxis
       end
 
       path = (base + path).gsub('//','/')
-      mustermann_options = {ignore_unknown_options: true}
       # Reject our own options
-      possible_mustermann_options = options.reject{|(k,_)| [:name].include?(k) }
-      pattern = Mustermann.new(path, mustermann_options.merge( possible_mustermann_options ))
-      route = Route.new(verb, pattern, version, **options)
+      route_name = options.delete(:name);
+      pattern = Mustermann.new(path, {ignore_unknown_options: true}.merge( options ))
+      route = Route.new(verb, pattern, version, name: route_name, **options)
       @routes << route
       route
     end

--- a/lib/praxis/tasks/routes.rb
+++ b/lib/praxis/tasks/routes.rb
@@ -7,7 +7,7 @@ namespace :praxis do
     table = Terminal::Table.new title: "Routes",
     headings:  [
       "Version", "Path", "Verb",
-      "Resource", "Action", "Implementation", "Name", "Primary"
+      "Resource", "Action", "Implementation", "Name", "Primary", "Options"
     ]
 
     rows = []
@@ -37,7 +37,8 @@ namespace :praxis do
               verb: route.verb,
               path: route.path,
               name: route.name,
-              primary: (action.primary_route == route ? 'yes' : '')
+              primary: (action.primary_route == route ? 'yes' : ''),
+              options: route.options
             })
         end
       end
@@ -49,8 +50,11 @@ namespace :praxis do
       puts JSON.pretty_generate(rows)
     when "table"
       rows.each do |row|
-        table.add_row(row.values_at(:version, :path, :verb, :resource,
-                                    :action, :implementation, :name, :primary))
+        formatted_options = row[:options].map{|(k,v)| "#{k}:#{v.to_s}"}.join("\n")
+        row_data = row.values_at(:version, :path, :verb, :resource,
+                                    :action, :implementation, :name, :primary)
+        row_data << formatted_options
+        table.add_row(row_data)
       end
       puts table
     else

--- a/lib/praxis/types/media_type_common.rb
+++ b/lib/praxis/types/media_type_common.rb
@@ -9,7 +9,7 @@ module Praxis
         def describe(shallow = false)
           hash = super
           unless shallow
-            hash.merge!(identifier: @identifier, description: @description)
+            hash.merge!(identifier: @identifier.to_s, description: @description)
           end
           hash
         end

--- a/spec/functional_spec.rb
+++ b/spec/functional_spec.rb
@@ -276,7 +276,7 @@ describe 'Functional specs' do
     end
   end
 
-  context 'wildcard routing' do
+  context 'wildcard verb routing' do
     it 'can terminate instances with POST' do
       post '/clouds/23/instances/1/terminate?api_version=1.0', nil, 'global_session' => session
       expect(last_response.status).to eq(200)
@@ -285,6 +285,19 @@ describe 'Functional specs' do
       post '/clouds/23/instances/1/terminate?api_version=1.0', nil, 'global_session' => session
       expect(last_response.status).to eq(200)
     end
+
+  end
+
+  context 'route options' do
+    it 'reach the endpoint that does not match the except clause' do
+      get '/clouds/23/otherinstances/_action/test?api_version=1.0', nil, 'global_session' => session
+      expect(last_response.status).to eq(200)
+    end
+    it 'does NOT reach the endpoint that matches the except clause' do
+      get '/clouds/23/otherinstances/_action/exceptional?api_version=1.0', nil, 'global_session' => session
+      expect(last_response.status).to eq(404)
+    end
+
 
   end
 
@@ -316,7 +329,7 @@ describe 'Functional specs' do
   end
 
   context 'update' do
-    
+
 
     let(:body) { JSON.pretty_generate(request_payload) }
     let(:content_type) { 'application/json' }
@@ -324,7 +337,7 @@ describe 'Functional specs' do
     before do
       patch '/clouds/1/instances/3?api_version=1.0', body, 'CONTENT_TYPE' => content_type, 'global_session' => session
     end
-  
+
     subject(:response_body) { JSON.parse(last_response.body) }
 
     context 'with an empty payload' do

--- a/spec/praxis/media_type_spec.rb
+++ b/spec/praxis/media_type_spec.rb
@@ -9,8 +9,8 @@ describe Praxis::MediaType do
   end
 
   let(:resource) do
-    double('address', 
-      id: 1, 
+    double('address',
+      id: 1,
       name: 'Home',
       owner: owner_resource,
       manager: manager_resource,
@@ -38,7 +38,7 @@ describe Praxis::MediaType do
   end
 
 
-  
+
   context 'accessor methods' do
     subject(:address_klass) { address.class }
 
@@ -62,7 +62,7 @@ describe Praxis::MediaType do
     end
 
     its(:description) { should be_kind_of(String) }
-    
+
     context 'links' do
       context 'with a custom links attribute' do
         subject(:person) { Person.new(owner_resource) }
@@ -70,7 +70,7 @@ describe Praxis::MediaType do
         its(:links)  { should be_kind_of(Array) }
         its(:links)  { should eq(owner_resource.links) }
       end
-  
+
       context 'using the links DSL' do
         subject(:address) { Address.new(resource) }
         its(:links)  { should be_kind_of(Address::Links) }
@@ -114,7 +114,7 @@ describe Praxis::MediaType do
         let(:snapshots_summary) { volume.snapshots_summary }
         let(:output) { volume.render(:default) }
         subject { links[:snapshots] }
-             
+
         its([:name]) { should eq(snapshots_summary.name) }
         its([:size]) { should eq(snapshots_summary.size) }
         its([:href]) { should eq(snapshots_summary.href) }
@@ -139,6 +139,33 @@ describe Praxis::MediaType do
     end
   end
 
+
+  context 'describing' do
+
+    subject(:described){ Address.describe }
+
+    its(:keys) { should match_array( [:attributes, :description, :family, :id, :identifier, :key, :name, :views] ) }
+    its([:attributes]) { should be_kind_of(::Hash) }
+    its([:description]) { should be_kind_of(::String) }
+    its([:family]) { should be_kind_of(::String) }
+    its([:id]) { should be_kind_of(::String) }
+    its([:name]) { should be_kind_of(::String) }
+    its([:identifier]) { should be_kind_of(::String) }
+    its([:key]) { should be_kind_of(::Hash) }
+    its([:views]) { should be_kind_of(::Hash) }
+
+    its([:description]) { should eq(Address.description) }
+    its([:family]) { should eq(Address.family) }
+    its([:id]) { should eq(Address.id) }
+    its([:name]) { should eq(Address.name) }
+    its([:identifier]) { should eq(Address.identifier.to_s) }
+    it 'should include the defined views' do
+      expect( subject[:views].keys ).to match( [:default, :master] )
+    end
+    it 'should include the defined attributes' do
+      expect( subject[:attributes].keys ).to match( [:id, :name, :owner, :custodian, :residents, :residents_summary, :links] )
+    end
+  end
 
   context 'using blueprint caching' do
     it 'has specs'

--- a/spec/praxis/router_spec.rb
+++ b/spec/praxis/router_spec.rb
@@ -75,9 +75,6 @@ describe Praxis::Router do
   end
 
   context ".add_route" do
-    before do
-      expect(router).to receive(:warn).with("other conditions not supported yet")
-    end
 
     let(:route){ double('route', options: [1], version: 1, verb: 'verb', path: 'path')}
     let(:target){ double('target') }
@@ -93,9 +90,6 @@ describe Praxis::Router do
       router.add_route(target ,route)
     end
 
-    it "raises warning when options are specified in route" do
-      expect(router.add_route(proc {'target'},route)).to eq(['path'])
-    end
   end
 
   context ".call" do
@@ -116,34 +110,34 @@ describe Praxis::Router do
       router.add_route(double("P"),double("route1", verb: 'POST', path: '/', options: {} , version: request_version))
       # Hijack the callable block in the routes (since there's no way to point back to the registered route object)
       router.instance_variable_get( :@routes )['POST'] = post_target_router
-        
+
     end
 
     context 'for routes without wildcards (a single POST route)' do
-      
+
       context 'and an incoming POST request' do
         it "finds a match and invokes it the route" do
           expect(router.call(request)).to eq(router_response_for_post)
         end
       end
       context 'and an incoming PUT request' do
-        let(:request_verb) { 'PUT' }      
+        let(:request_verb) { 'PUT' }
         it "does not find a route" do
           response_code, _ , _ = router.call(request)
           expect(response_code).to be(404)
         end
       end
     end
-    
+
     context 'for routes with wildcards (a POST and a * route)' do
       before do
         router.add_route(double("*"),double("route2", verb: 'ANY', path: '/*', options: {} , version: request_version))
         # Hijack the callable block in the routes (since there's no way to point back to the registered route object)
-        router.instance_variable_get( :@routes )['ANY'] = any_target_router        
+        router.instance_variable_get( :@routes )['ANY'] = any_target_router
       end
-      
+
       context 'and an incoming PUT request' do
-        let(:request_verb) { 'PUT' }      
+        let(:request_verb) { 'PUT' }
         it "it can successfully find a match using the wildcard target" do
           expect(router.call(request)).to eq(router_response_for_wildcard)
         end
@@ -164,7 +158,7 @@ describe Praxis::Router do
     end
 
     context "when not_found is returned" do
-      let(:request_verb) { 'DELETE' }      
+      let(:request_verb) { 'DELETE' }
       let(:router_response){ :not_found }
 
 
@@ -175,7 +169,7 @@ describe Praxis::Router do
       end
 
       context 'with X-Cascade disabled' do
-        let(:config) { Praxis::Application.instance.config.praxis } 
+        let(:config) { Praxis::Application.instance.config.praxis }
         before do
           expect(config).to receive(:x_cascade).and_return(false)
         end

--- a/spec/praxis/routing_config_spec.rb
+++ b/spec/praxis/routing_config_spec.rb
@@ -39,7 +39,8 @@ describe Praxis::RoutingConfig do
 
   context '#add_route' do
     let(:path) { '/people' }
-    let(:route) { routing_config.add_route 'GET', path }
+    let(:options) { {} }
+    let(:route) { routing_config.add_route 'GET', path, **options}
 
     it 'returns a corresponding Praxis::Route' do
       expect(route).to be_kind_of(Praxis::Route)
@@ -47,6 +48,24 @@ describe Praxis::RoutingConfig do
 
     it 'appends the Route to the set of routes' do
       expect(routing_config.routes).to include(route)
+    end
+
+    context 'passing  options' do
+      let(:options){ {name: 'alternative', except: '/special' } }
+
+      it 'uses :name to name the route' do
+        expect(route.name).to eq('alternative')
+      end
+
+      it 'does NOT pass the name option down to mustermann' do
+        expect(Mustermann).to receive(:new).with(path, hash_excluding({name: 'alternative'}))
+        expect(route.name).to eq('alternative')
+      end
+
+      it 'passes them through the underlying mustermann object (telling it to ignore unknown ones)' do
+        expect(Mustermann).to receive(:new).with(path, hash_including(ignore_unknown_options: true, except: '/special'))
+        expect(route.options).to eq( { except: '/special' })
+      end
     end
 
     context 'with prefix defined' do

--- a/spec/spec_app/app/controllers/instances.rb
+++ b/spec/spec_app/app/controllers/instances.rb
@@ -3,7 +3,7 @@ class Instances < BaseClass
 
   implements ApiResources::Instances
   include Concerns::BasicApi
-  
+
   before :validate, actions: [:index]  do |controller|
     #p [:before, :validate, :params_and_headers, controller.request.action.name]
   end
@@ -32,7 +32,7 @@ class Instances < BaseClass
     blk.call
     #puts "Decorator two end"
   end
-  
+
   around :action, actions: [:index] do |controller, blk|
     #puts "Decorator three (index action) start"
     blk.call
@@ -104,4 +104,8 @@ class Instances < BaseClass
     response
   end
 
+  def exceptional(cloud_id:, splat:)
+    response.headers['Content-Type'] = 'application/vnd.acme.instance'
+    response
+  end
 end

--- a/spec/spec_app/design/resources/instances.rb
+++ b/spec/spec_app/design/resources/instances.rb
@@ -4,15 +4,15 @@ module ApiResources
 
     media_type Instance
     version '1.0'
-    
+
     # :show action is the canonical path for this resource.
     # Note that the following is redundant, since :show is the default canonical path if none is defined.
     canonical_path :show
-    
+
     prefix '/clouds/:cloud_id/instances'
 
     trait :authenticated
-    
+
     action_defaults do
       requires_ability :read
 
@@ -29,7 +29,7 @@ module ApiResources
       params do
         attribute :response_content_type, String, default: 'application/vnd.acme.instance;type=collection'
       end
-      
+
       headers do
         # BOTH ARE EQUIVALENT
         #key "FOO", String, required: true
@@ -128,14 +128,14 @@ module ApiResources
       routing do
         any '/:id/terminate'
       end
-      
+
       requires_ability :terminate
 
       params do
         attribute :id
       end
 
-      payload do 
+      payload do
         attribute :when, DateTime
       end
 
@@ -174,11 +174,15 @@ module ApiResources
     end
 
 
-    action :absolute do
-      routing do 
-        prefix '/'
-        get '/absolutely'
+    action :exceptional do
+      routing do
+        prefix '//clouds/:cloud_id/otherinstances'
+        get '/_action/*', except: '*/_action/exceptional'
       end
+      params do
+        attribute :splat, Attributor::Collection.of(String), required: true
+      end
+      response :ok
     end
     # OTHER USAGES:
     #   note: these are all hypothetical, pending, brainstorming usages.


### PR DESCRIPTION
Allow route options to be passed to the underlying router (i.e. Mustermann at the moment)
  * routes defined in the `routing` blocks can now take any extra options which will be passed down to the Mustermann routing engine. Unknown options will be ignored!
  * Displaying routes (`praxis routes` or `rake praxis:routes`) will now include any options defined in a route.
  * Added an example on the instances resource of the embedded spec_app to show how to use the advanced `*` pattern and the `:except` Mustermann options (along with the required `:splat` attribute).

closes #166 