### PR TITLE
Build copies unrecognised files into output

### DIFF
--- a/lib/api_browser/Gruntfile.js
+++ b/lib/api_browser/Gruntfile.js
@@ -220,7 +220,12 @@ module.exports = function(grunt) {
           cwd: userDocsPath,
           dest: buildPath,
           src: [
-            'api/**'
+            '**/*',
+            '!**/*.{js,scss,sass,less,coffee}',
+            '!views/**',
+            '!**/.*',
+            '!output/**'
+
           ]
         }]
       }


### PR DESCRIPTION
This means you can now have images and other custom files in your docs folder and these will end up unmodified in `docs/output` when running `rake praxis:docs:build`.