### PR TITLE
Bootloader hooks for sub-stages are not called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## next
 
 * Refined path-based versioning:
-  * Added `ApiGeneralInfo#version_with`, which defaults to `[:header, :params`] and may be set to `:path` to use path-based versioning. 
-  * Added support for specifying an `:api_version` placeholder to the global version's `ApiGeneralInfo#base_path`. 
+  * Added `ApiGeneralInfo#version_with`, which defaults to `[:header, :params`] and may be set to `:path` to use path-based versioning.
+  * Added support for specifying an `:api_version` placeholder to the global version's `ApiGeneralInfo#base_path`.
   * Deprecated `ResourceDefinition.version using: :path` option, use `ApiGeneralInfo#version_with` instead.
+* Fix bug where before/after hooks set on sub-stages of `:app` would not be triggered
 
 
 ## 0.16.1

--- a/lib/praxis/bootloader_stages/subgroup_loader.rb
+++ b/lib/praxis/bootloader_stages/subgroup_loader.rb
@@ -20,6 +20,7 @@ module Praxis
         order.each do |group|
           @stages << FileLoader.new(group, application, path: [name, group])
         end
+        setup_deferred_callbacks!
       end
     end
 

--- a/spec/spec_app/config/environment.rb
+++ b/spec/spec_app/config/environment.rb
@@ -29,6 +29,15 @@ Praxis::Application.configure do |application|
   application.config.praxis.validate_responses = true
   application.config.praxis.show_exceptions = true
 
+  # Silly callback code pieces to test that the deferred callbacks work even for sub-stages
+  application.bootloader.after :app, :models do
+    PersonModel.identity(:other_id)
+  end
+  application.bootloader.after :app do
+    raise "After sub-stage hooks not working!" unless PersonModel.identities.include? :other_id
+  end
+
+
   application.layout do
     layout do
       map :initializers, 'config/initializers/**/*'

--- a/spec/spec_app/config/environment.rb
+++ b/spec/spec_app/config/environment.rb
@@ -29,6 +29,7 @@ Praxis::Application.configure do |application|
   application.config.praxis.validate_responses = true
   application.config.praxis.show_exceptions = true
 
+  # FIXME: until we have a better way to unit test such a feature...
   # Silly callback code pieces to test that the deferred callbacks work even for sub-stages
   application.bootloader.after :app, :models do
     PersonModel.identity(:other_id)


### PR DESCRIPTION
* Fix bug where before/after hooks set on sub-stages of `:app` would not be triggered

closes #179 

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>