### PR TITLE
Update MediaType so it can take a hash

### DIFF
--- a/lib/praxis/media_type.rb
+++ b/lib/praxis/media_type.rb
@@ -56,11 +56,28 @@ module Praxis
   #   end
   class MediaType < Praxis::Blueprint
     include Types::MediaTypeCommon
+    @struct = nil
 
     class DSLCompiler < Attributor::DSLCompiler
       def links(&block)
         attribute :links, Praxis::Links.for(options[:reference]), dsl_compiler: Links::DSLCompiler, &block
       end
+    end
+
+    def self.new(object, decorators=nil)
+      if object.is_a?(Hash)
+        object = self.to_struct.new(*object.with_indifferent_access.values_at(*self.get_all_attributes_and_links))
+      end
+      super(object, decorators)
+    end
+
+    def self.get_all_attributes_and_links
+      self.attributes.keys + self::Links.links.values
+    end
+
+    def self.to_struct
+      return @struct if @struct
+      @struct = Struct.new(*self.get_all_attributes_and_links)
     end
 
     def self.attributes(opts={}, &block)
@@ -80,7 +97,7 @@ module Praxis
         RUBY
       end
     end
-    
+
   end
 
 end

--- a/spec/praxis/media_type_spec.rb
+++ b/spec/praxis/media_type_spec.rb
@@ -96,32 +96,53 @@ describe Praxis::MediaType do
   end
 
   context "rendering" do
-    subject(:output) { address.render(:default) }
+    context "passing an object" do
+      subject(:output) { address.render(:default) }
 
-    its([:id])    { should eq(address.id) }
-    its([:name])  { should eq(address.name) }
-    its([:owner]) { should eq(Person.dump(owner_resource, view: :default)) }
+      its([:id])    { should eq(address.id) }
+      its([:name])  { should eq(address.name) }
+      its([:owner]) { should eq(Person.dump(owner_resource, view: :default)) }
 
 
-    context 'links' do
-      subject(:links) { output[:links] }
+      context 'links' do
+        subject(:links) { output[:links] }
 
-      its([:owner]) { should eq(Person.dump(owner_resource, view: :link)) }
-      its([:super]) { should eq(Person.dump(manager_resource, view: :link)) }
+        its([:owner]) { should eq(Person.dump(owner_resource, view: :link)) }
+        its([:super]) { should eq(Person.dump(manager_resource, view: :link)) }
 
-      context 'for a collection summary' do
-        let(:volume) { Volume.example }
-        let(:snapshots_summary) { volume.snapshots_summary }
-        let(:output) { volume.render(:default) }
-        subject { links[:snapshots] }
+        context 'for a collection summary' do
+          let(:volume) { Volume.example }
+          let(:snapshots_summary) { volume.snapshots_summary }
+          let(:output) { volume.render(:default) }
+          subject { links[:snapshots] }
 
-        its([:name]) { should eq(snapshots_summary.name) }
-        its([:size]) { should eq(snapshots_summary.size) }
-        its([:href]) { should eq(snapshots_summary.href) }
+          its([:name]) { should eq(snapshots_summary.name) }
+          its([:size]) { should eq(snapshots_summary.size) }
+          its([:href]) { should eq(snapshots_summary.href) }
+        end
       end
     end
 
+    context "passing a hash" do
+      let(:resource) do
+        {
+          id: 1,
+          name: 'Home',
+          owner: owner_resource,
+          manager: manager_resource
+        }
+      end
 
+      subject(:output) { address.render(:default) }
+
+      its([:id])    { should eq(address.id) }
+      its([:name])  { should eq(address.name) }
+      its([:owner]) { should eq(Person.dump(owner_resource, view: :default)) }
+
+      it "converts resource to a struct" do
+        expect(address.object.is_a?(Struct)).to be(true)
+      end
+    end
   end
 
   context '.example' do


### PR DESCRIPTION
When constructing a MediaType, the constructor now allows
a hash to be passed instead of just an object.  If a hash is passed
then it is converted into a Struct.  The Struct is created from a
combination of attributes and links that are defined in the MediaType.