### PR TITLE
Adds a multipart and string template

### DIFF
--- a/lib/api_browser/app/js/factories/template_for.js
+++ b/lib/api_browser/app/js/factories/template_for.js
@@ -30,9 +30,14 @@ app.provider('templateFor', function() {
     resolvers.unshift(resolver);
   };
 
-  this.register(/*ngInject*/function payloadResolver($family, $requestedTemplate) {
+  this.register(/*ngInject*/function payloadResolver($family, $type, $requestedTemplate) {
     if ($requestedTemplate === 'standalone') {
+      if ($type === 'Praxis::Multipart') {
+        return 'views/types/standalone/multipart.html'
+      }
       switch ($family) {
+        case 'string':
+          return 'views/types/standalone/string.html';
         case 'hash':
           return 'views/types/standalone/struct.html';
         default:

--- a/lib/api_browser/app/views/types/standalone/multipart.html
+++ b/lib/api_browser/app/views/types/standalone/multipart.html
@@ -1,0 +1,10 @@
+<p>This is a mulipart body, which accepts the following parts:</p>
+
+<div ng-repeat="(key, info) in details">
+  <h4><code>{{key}}</code></h4>
+  <p>{{info.required ? 'required' : 'optional'}}</p>
+  <!-- Headers would go here -->
+  <type-placeholder type="info.type" template="standalone" details="info"></type-placeholder>
+</div>
+
+<!-- Example should render here -->

--- a/lib/api_browser/app/views/types/standalone/string.html
+++ b/lib/api_browser/app/views/types/standalone/string.html
@@ -1,0 +1,2 @@
+<p><b>Type:</b> String</p>
+<p><b>Example:</b> <code>{{details.options.example}}</code><p>

--- a/lib/api_browser/app/views/types/standalone/struct.html
+++ b/lib/api_browser/app/views/types/standalone/struct.html
@@ -1,1 +1,1 @@
-<attribute-table attributes="details" show-groups="true"></attribute-table>
+<attribute-table attributes="type.attributes" show-groups="true"></attribute-table>


### PR DESCRIPTION
This adds a string and multipart templates.

Currently this is missing some things, that are blocked elsewhere:

- [ ] Praxis::Multipart should really have its own family: `multipart`
- [ ] It should add information about headers the part can have
- [x] There should be an example of how it should look (i.e. boundaries and everything)
