### PR TITLE
Refactored `ValidationError` body for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,14 @@
   * This also removes an undocumented feature that did something similar.
   * Fixes an issue where Struct properties wouldn't be displayed.
 * Added `endpoint` directive to global API info, only used for documentation purposes.
-* Added `ResourceDefinition.parent` directive to define a parent resource. 
+* Added `ResourceDefinition.parent` directive to define a parent resource.
   * The parent's `canonical_path` is used as the base of the child's routes.
   * Any parameters in the parent's route will also be applied as defaults in the child. The last route parameter is assumed to be an 'id'-type parameter, and is prefixed with the parent's snake-cased singular name. I.e., `id` from a `Volume` parent will be renamed to `volume_id`. Any other parameters are copied unchanged.
     * This behavior can be overridden by providing a mapping hash of the form `{parent_name => child_name}` to the `parent` directive. See [VolumeSnapshots](spec/spec_app/design/resources/volume_snapshots.rb) for an example.
-
+* Backwards incompatible Change: Refactored `ValidationError` to be more consistent with the reported fields
+  * Changed `message` for `summary`. Always present, and should provide a quick description of the type of error encountered. For example: "Error loading payload data"
+  * Semantically changed `errors` to always have the details of one or many errors that have occurred. For example: "Unknown key received: :foobar while loading $.payload.user"
+  * Note: if you are an application that used and tested against the previous `message` field you will need to adjust your tests to check for the values in the `summary` field and or the `errors` contents. But it will now be a much more consistent experience that will allow API clients to notify of the exact errors and details to their clients.
 
 ## 0.16.1
 

--- a/lib/praxis/request.rb
+++ b/lib/praxis/request.rb
@@ -96,7 +96,7 @@ module Praxis
 
     def version
       result = nil
-      
+
       Array(Application.instance.versioning_scheme).find do |mode|
         case mode
         when :header;

--- a/lib/praxis/request_stages/response.rb
+++ b/lib/praxis/request_stages/response.rb
@@ -2,16 +2,9 @@ module Praxis
   module RequestStages
 
     class Response < RequestStage
-      WHITELIST_RESPONSES = [:validation_error]
 
       def execute
         response = controller.response
-
-        unless action.responses.include?(response.response_name) || WHITELIST_RESPONSES.include?(response.response_name)
-          raise Exceptions::InvalidResponse.new(
-            "Response #{response.name.inspect} is not allowed for #{action.name.inspect}"
-          )
-        end
 
         response.handle
 
@@ -19,7 +12,7 @@ module Praxis
           response.validate(action)
         end
       rescue Exceptions::Validation => e
-        controller.response = Responses::ValidationError.new(exception: e)
+        controller.response = Responses::ValidationError.new(summary: "Error validating response", exception: e)
         retry
       end
 

--- a/lib/praxis/request_stages/validate.rb
+++ b/lib/praxis/request_stages/validate.rb
@@ -8,14 +8,14 @@ module Praxis
         # Add our sub-stages
         @stages = [
           RequestStages::ValidateParamsAndHeaders.new(:params_and_headers, context, parent: self),
-          RequestStages::ValidatePayload.new(:payload, context, parent: self) 
+          RequestStages::ValidatePayload.new(:payload, context, parent: self)
         ]
       end
 
       def execute
         super
       rescue Attributor::AttributorException => e
-        return Responses::ValidationError.new(exception: e)
+        return Responses::ValidationError.new(summary: "Error validating request", exception: e)
       end
 
     end

--- a/lib/praxis/request_stages/validate_params_and_headers.rb
+++ b/lib/praxis/request_stages/validate_params_and_headers.rb
@@ -28,7 +28,7 @@ module Praxis
         errors += request.validate_params(CONTEXT_FOR[:params])
 
         if errors.any?
-          return Responses::ValidationError.new(errors: errors)
+          return Responses::ValidationError.new(summary: "Error validating request data", errors: errors)
         end
       end
 

--- a/lib/praxis/request_stages/validate_payload.rb
+++ b/lib/praxis/request_stages/validate_payload.rb
@@ -19,15 +19,14 @@ module Praxis
           begin
             request.load_payload(CONTEXT_FOR[:payload])
           rescue Attributor::AttributorException => e
-            message = e.message
-            message << ". For request Content-Type: '#{request.content_type}'"
-            return Responses::ValidationError.new(exception: e, message: message)
+            message = "Error loading payload. Used Content-Type: '#{request.content_type}'"
+            return Responses::ValidationError.new(exception: e, summary: message)
           end
           Attributor::AttributeResolver.current.register("payload",request.payload)
 
           errors = request.validate_payload(CONTEXT_FOR[:payload])
           if errors.any?
-            return Responses::ValidationError.new(errors: errors)
+            return Responses::ValidationError.new(summary: "Errors validating payload data", errors: errors)
           end
         end
       end

--- a/lib/praxis/responses/validation_error.rb
+++ b/lib/praxis/responses/validation_error.rb
@@ -3,20 +3,20 @@ module Praxis
   module Responses
 
     class ValidationError < BadRequest
-      def initialize(errors: nil, exception: nil, message: nil, **opts)
+      def initialize(summary: , errors: nil, exception: nil, **opts)
         super(**opts)
         @headers['Content-Type'] = 'application/json' #TODO: might want an error mediatype
         @errors = errors
+        unless @errors # The exception message will the the only error if no errors are passed in
+           @errors = [exception.message] if exception && exception.message
+         end
         @exception = exception
-        @message = message || (exception && exception.message)
+        @summary = summary
       end
 
       def format!
-        if @errors
-          @body = {name: 'ValidationError', errors: @errors}
-        elsif @message
-          @body = {name: 'ValidationError', message: @message}
-        end
+        @body = {name: 'ValidationError', summary: @summary }
+        @body[:errors] = @errors if @errors
 
         if @exception && @exception.cause
           @body[:cause] = {name: @exception.cause.class.name, message: @exception.cause.message}

--- a/spec/functional_spec.rb
+++ b/spec/functional_spec.rb
@@ -34,8 +34,8 @@ describe 'Functional specs' do
         response = JSON.parse(last_response.body)
 
         expect(response['name']).to eq('ValidationError')
-
-        expect(response["message"]).to match(/Bad Content-Type/)
+        expect(response['summary']).to eq("Error validating response")
+        expect(response['errors'].first).to match(/Bad Content-Type/)
       end
 
       context 'with response validation disabled' do
@@ -326,12 +326,12 @@ describe 'Functional specs' do
     it 'returns a useful error message' do
       body = JSON.parse(last_response.body)
       expect(body['name']).to eq('ValidationError')
-      expect(body['message']).to match("For request Content-Type: 'application/x-www-form-urlencoded'")
+      expect(body['summary']).to match("Error loading payload. Used Content-Type: 'application/x-www-form-urlencoded'")
+      expect(body['errors']).to_not be_empty
     end
   end
 
   context 'update' do
-
 
     let(:body) { JSON.pretty_generate(request_payload) }
     let(:content_type) { 'application/json' }

--- a/spec/praxis/responses/validation_error_spec.rb
+++ b/spec/praxis/responses/validation_error_spec.rb
@@ -2,9 +2,10 @@ require 'spec_helper'
 
 
 describe Praxis::Responses::ValidationError do
-  
+
+  let(:summary){ "Something happened here" }
   context 'a basic response' do
-    subject(:response) { Praxis::Responses::ValidationError.new }
+    subject(:response) { Praxis::Responses::ValidationError.new(summary: summary) }
     it 'always sets the json content type' do
       expect(response.name).to be(:validation_error)
       expect(response.status).to be(400)
@@ -12,51 +13,67 @@ describe Praxis::Responses::ValidationError do
       expect(response.headers).to have_key('Content-Type')
       expect(response.headers['Content-Type']).to eq('application/json')
       expect(response.instance_variable_get(:@errors)).to be(nil)
-      expect(response.instance_variable_get(:@exception)).to be(nil)      
+      expect(response.instance_variable_get(:@exception)).to be(nil)
     end
   end
-  
+
   context '.format!' do
     let(:errors) { [1,2] }
     let(:cause){ Exception.new( "cause message") }
     let(:exception_message){ "exception message" }
     let(:exception){ nil }
-    subject(:response) { Praxis::Responses::ValidationError.new(errors: errors, exception: exception) }
+    subject(:response) { Praxis::Responses::ValidationError.new(summary: summary, errors: errors, exception: exception) }
     before do
       expect(response.body).to be_empty
     end
     context 'when errors' do
       it 'it fills the errors key' do
         response.format!
-        expect(response.body).to eq({name: 'ValidationError', errors: errors})
+        expect(response.body).to eq({name: 'ValidationError', summary: summary, errors: errors})
       end
     end
-    
+
     context 'without errors but with an exception' do
       let(:errors) { nil }
       let(:exception){ double("exception", message: exception_message, cause: cause)}
       before do
          response.format!
+         expect(response.body.keys).to include(:name,:summary)
+         expect(response.body[:name]).to eq('ValidationError')
+         expect(response.body[:summary]).to eq(summary)
       end
-      context 'without cause' do
-        let(:cause){ nil}
-        it 'it fills the message' do
-          expect(response.body).to eq({name: 'ValidationError', message: exception_message} )
+
+      context 'that has a message' do
+        it 'fills the errors array with the exception message' do
+          expect(response.body).to have_key(:errors)
+          expect(response.body[:errors]).to eq([exception.message])
         end
       end
-  
+
+      context 'that does not contain a message' do
+        let(:exception_message){ nil }
+        it 'does not touch the errors key' do
+          expect(response.body).to_not have_key(:errors)
+        end
+      end
+
+      context 'without cause' do
+        let(:cause){ nil}
+        it 'does not include it in the output' do
+          expect(response.body).to_not have_key(:cause)
+        end
+      end
+
       context 'with a cause' do
-        it 'it fills the message' do
-          expect(response.body.keys).to eq([:name,:message,:cause])
-          expect(response.body[:name]).to eq('ValidationError')
-          expect(response.body[:message]).to eq(exception_message)
+        it 'it fills the cause too' do
+          expect(response.body).to have_key(:cause)
           expect(response.body[:cause]).to eq({name: cause.class.name, message: cause.message })
         end
       end
     end
-    
+
   end
-  
+
   context 'its response template' do
     let(:template){ Praxis::ApiDefinition.instance.responses[:validation_error] }
     it 'is registered with the ApiDefinition' do


### PR DESCRIPTION
* Changed `message` for `summary`. Always present, and should provide a quick description of the type of error encountered. For example: "Error loading payload data"
* Semantically changed `errors` to always have the details of one or many errors that have occurred. For example: "Unknown key received: :foobar while loading $.payload.user"

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>