### PR TITLE
Adds expandable tree-like navigation for child resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ config option, and uses the `media_type` defined for the response definition.
 * The `header` directive inside `ActionDefinition#headers` now accepts an optional second `type` parameter that may be used to override the default `String` type that would be used.
 * Added `Praxis::Handlers::Plain` encoder for 'text/plain'.
 * Fixed `Praxis::Handlers::XML ` handler to transform dashes to underscores and treat empty hashes like ActiveSupport does.
+* Adds hierarchival navigation to the doc browser.
+* Adds a ConfigurationProvider allowing for easy doc customization.
 
 ## 0.16.1
 

--- a/lib/api_browser/app/js/controllers/menu.js
+++ b/lib/api_browser/app/js/controllers/menu.js
@@ -1,5 +1,5 @@
 app.controller('MenuCtrl', function($scope, $state, Documentation) {
-
+  var parentLookup = {};
   $scope.versions = [];
   $scope.resources = {};
   $scope.others = {};
@@ -7,8 +7,7 @@ app.controller('MenuCtrl', function($scope, $state, Documentation) {
   $scope.currentType = '';
   $scope.active = {};
 
-  Documentation.getIndex().success(function(index) {
-
+  var menuPromise = Documentation.getIndex().success(function(index) {
     _.forEach(index, function(items, version) {
       $scope.versions.push(version);
       var resources = $scope.resources[version] = [];
@@ -16,8 +15,11 @@ app.controller('MenuCtrl', function($scope, $state, Documentation) {
 
       _.forEach(items, function(item, name) {
         var link = { name: name, stateRef: '' };
-
+        if (item.parent) {
+          link.parent = item.parent;
+        }
         if (item.controller) {
+          parentLookup[item.controller] = link;
           link.stateRef = $state.href('root.controller', { version: version, controller: item.controller });
           link.typeName = item.controller;
           resources.push(link);
@@ -30,6 +32,17 @@ app.controller('MenuCtrl', function($scope, $state, Documentation) {
           link.typeName = item.kind;
           others.push(link);
         }
+      });
+      function getPath(r) {
+        if (r.parent) {
+          var path = getPath(parentLookup[r.parent]) + ':' + _.last(r.typeName.split('-'));
+          return path;
+        }
+        return _.last(r.typeName.split('-'));
+      }
+      $scope.resources[version] = _.map(_.sortBy(resources, getPath), function(r) {
+        r.grandfather = grandfatherType(r.typeName);
+        return r;
       });
     });
     var numeralVersions = _.filter($scope.versions, function(n) { return !isNaN(parseFloat(n)); })
@@ -50,9 +63,20 @@ app.controller('MenuCtrl', function($scope, $state, Documentation) {
     return $scope.others[$scope.selectedVersion];
   };
 
+  function grandfatherType(id) {
+    var self = parentLookup[id];
+    if (self.parent) {
+      return grandfatherType(self.parent);
+    }
+    return id;
+  }
+
   $scope.$on('$stateChangeSuccess', function(e, state, params) {
     if (params.version) $scope.selectedVersion = params.version;
     $scope.currentType = params.controller || params.type;
+    menuPromise.then(function() {
+      $scope.selectedGrandfatherType = params.controller && grandfatherType(params.controller);
+    });
     $scope.active.resources = state.name !== 'root.type';
     $scope.active.schemas = state.name === 'root.type';
   });

--- a/lib/api_browser/app/js/factories/Configuration.js
+++ b/lib/api_browser/app/js/factories/Configuration.js
@@ -1,0 +1,13 @@
+// Use this to provide settings for the doc browser
+app.provider('Configuration', function() {
+  this.title = 'API Browser';
+  this.versionLabel = 'API Version';
+  this.expandChildren = true;
+
+  this.$get = function() {
+    return this;
+  };
+}).run(function(Configuration, $rootScope, $document) {
+  _.extend($rootScope, _.omit(Configuration, '$get'));
+  $document[0].title = Configuration.title;
+});

--- a/lib/api_browser/app/sass/modules/_sidebar.scss
+++ b/lib/api_browser/app/sass/modules/_sidebar.scss
@@ -34,6 +34,12 @@
     &:last-of-type {
       border-bottom: 0 none;
     }
+    &.child-resource {
+      padding-left: 2.5em;
+    }
+    &.group-selected {
+      border-left: 2px solid $link-color;
+    }
   }
 }
 

--- a/lib/api_browser/app/views/home.html
+++ b/lib/api_browser/app/views/home.html
@@ -1,7 +1,5 @@
-<!-- Home -->
-
 <div class="jumbotron">
   <h2>
-    API Doc Browser
+    {{:: title}}
   </h2>
 </div>

--- a/lib/api_browser/app/views/layout.html
+++ b/lib/api_browser/app/views/layout.html
@@ -1,5 +1,4 @@
-﻿<!-- layout -->
-<ng-include src="'views/navbar.html'"></ng-include>
+﻿<ng-include src="'views/navbar.html'"></ng-include>
 
 <div class="container" ng-cloak>
   <div class="row">

--- a/lib/api_browser/app/views/menu.html
+++ b/lib/api_browser/app/views/menu.html
@@ -1,10 +1,10 @@
-<div class="sidebar fixed-if-fits">
+<div class="sidebar fixed-if-fits hidden-print">
   <div class="row">
     <div class="col-sm-12">
       <p>
         <div class="btn-group" dropdown is-open="status.isopen">
           <button type="button" class="btn btn-success dropdown-toggle" ng-disabled="disabled">
-            API Version: {{selectedVersion}} <span class="caret"></span>
+            {{:: versionLabel}}: {{selectedVersion}} <span class="caret"></span>
           </button>
           <ul class="dropdown-menu col-sm-12" role="menu">
             <li ng-repeat="version in versions">
@@ -23,7 +23,8 @@
             <a ng-repeat="link in availableResources()"
                href="{{link.stateRef}}"
                class="list-group-item"
-               ng-class="{active: link.typeName == currentType}">
+               ng-hide="expandChildren && link.parent && selectedGrandfatherType != link.grandfather"
+               ng-class="{active: link.typeName == currentType, 'child-resource': link.parent, 'group-selected': selectedGrandfatherType ==  link.grandfather}">
               {{ link.name }}
             </a>
           </div>

--- a/lib/api_browser/app/views/navbar.html
+++ b/lib/api_browser/app/views/navbar.html
@@ -2,7 +2,7 @@
   <div class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="container">
       <div class="navbar-header">
-        <a class="navbar-brand" href="#">API Browser</a>
+        <a class="navbar-brand" href="#">{{:: title}}</a>
       </div>
     </div>
   </div>

--- a/lib/praxis/restful_doc_generator.rb
+++ b/lib/praxis/restful_doc_generator.rb
@@ -263,7 +263,7 @@ module Praxis
       @resources.each do |r|
         index[r.version] ||= Hash.new
         info = {controller: r.id, name: r.name}
-        info[:parent] = r.parent.id if r.parent
+        info[:parent] = r.parent.controller ? r.parent.controller.id : r.parent.id if r.parent
         if r.media_type
           info[:media_type] = r.media_type.id
           media_types_seen_from_controllers << r.media_type


### PR DESCRIPTION
Currently the styling works only for one level of nesting.

![subnavs](https://cloud.githubusercontent.com/assets/69144/8476073/d301fc96-20bd-11e5-9703-14106209cf16.gif)

This also adds a `ConfigurationProvider` service, that allows configuring some aspects of the doc browser. Namely if you don't like the fact that subresources are hidden by default, you can add this to your app.js:

```javascript
angular.module('DocBrowser', ['PraxisDocBrowser'])
.config(function(ConfigurationProvider) {
  ConfigurationProvider.expandChildren = false;
});
```