### PR TITLE
Fixes Broken Build and version Selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## next
 
+## 0.17.1
+
+* Fixes an issue that would make exported documentation broken.
+* Fixes an issue that would make the version selector broken.
 
 ## 0.17.0
 

--- a/lib/api_browser/app/js/factories/template_for.js
+++ b/lib/api_browser/app/js/factories/template_for.js
@@ -30,7 +30,8 @@ app.provider('templateFor', function() {
     resolvers.unshift(resolver);
   };
 
-  this.register(/*ngInject*/function payloadResolver($family, $requestedTemplate) {
+  this.register(function payloadResolver($family, $requestedTemplate) {
+    'ngInject';
     if ($requestedTemplate === 'standalone') {
       switch ($family) {
         case 'hash':
@@ -41,7 +42,8 @@ app.provider('templateFor', function() {
     }
   });
 
-  this.register(/*ngInject*/function typeResolver($family, $type, $requestedTemplate) {
+  this.register(function typeResolver($family, $type, $requestedTemplate) {
+    'ngInject';
     if ($requestedTemplate === 'embedded') {
       if ($type === 'Links') {
         return 'views/types/embedded/links.html';
@@ -55,7 +57,8 @@ app.provider('templateFor', function() {
     }
   });
 
-  this.register(/*ngInject*/function labelResolver($typeDefinition, $requestedTemplate, primitives) {
+  this.register(function labelResolver($typeDefinition, $requestedTemplate, primitives) {
+    'ngInject';
     if ($requestedTemplate === 'label') {
       if (_.contains(primitives, $typeDefinition.name)) {
         return 'views/types/label/primitive.html';

--- a/lib/api_browser/app/views/menu.html
+++ b/lib/api_browser/app/views/menu.html
@@ -2,8 +2,8 @@
   <div class="row">
     <div class="col-sm-12">
       <p>
-        <div class="btn-group" dropdown is-open="status.isopen">
-          <button type="button" class="btn btn-success dropdown-toggle" ng-disabled="disabled">
+        <div ng-if="versions.length > 1" dropdown auto-close="outsideClick">
+          <button type="button" class="btn btn-success" dropdown-toggle ng-disabled="disabled">
             {{:: versionLabel}}: {{selectedVersion}} <span class="caret"></span>
           </button>
           <ul class="dropdown-menu col-sm-12" role="menu">
@@ -11,6 +11,9 @@
               <a ng-click="select(version)" dropdown-toggle>{{version}}</a>
             </li>
           </ul>
+        </div>
+        <div ng-if="versions.length == 1" class="btn btn-success">
+          {{:: versionLabel}}: {{selectedVersion}}
         </div>
       </p>
     </div>


### PR DESCRIPTION
The issue for the builds was that some custom DI was not protected from overly aggressive minification.

@careo I think this should be released ASAP, as the build functionality is used in production.

This closes #220 and #218.