### PR TITLE
MultipartArray payload_type defaults to Attributor::Struct.

### DIFF
--- a/lib/praxis/types/multipart_array.rb
+++ b/lib/praxis/types/multipart_array.rb
@@ -51,9 +51,7 @@ module Praxis
         @name_type = Attributor.resolve_type type
       end
 
-      def self.payload_type(type=nil, **opts, &block)
-        return @payload_type if type.nil?
-
+      def self.payload_type(type=Attributor::Struct, **opts, &block)
         @payload_type = Attributor.resolve_type(type)
         @payload_attribute = Attributor::Attribute.new(@payload_type, **opts, &block)
         @part_attribute = nil
@@ -96,7 +94,7 @@ module Praxis
                                                   filename_attribute: filename_attribute
                                                   )
         else
-          payload_attribute = compiler.define(name, payload_type || self.payload_type, **opts)
+          payload_attribute = compiler.define(name, payload_type || @payload_type, **opts)
           self.attributes[name] = compiler.define(name, Praxis::MultipartPart,
                                                   payload_attribute: payload_attribute,
                                                   filename_attribute: filename_attribute
@@ -174,7 +172,7 @@ module Praxis
               end
             end
           else
-            hash[:part_payload] = {type: payload_type.describe(true)}
+            hash[:part_payload] = {type: @payload_type.describe(true)}
           end
         end
         hash
@@ -188,7 +186,7 @@ module Praxis
           end
 
           sub_hash = part_attribute.describe(shallow, example: sub_example)
-          
+
 
           if (options = sub_hash.delete(:options))
             sub_hash[:options] = {}
@@ -204,7 +202,7 @@ module Praxis
           end
 
           sub_hash[:type] = MultipartPart.describe(shallow, example: sub_example, options: part_attribute.options)
-          
+
 
           parts[part_name] = sub_hash
         end
@@ -226,7 +224,7 @@ module Praxis
       end
 
       def payload_type
-        self.class.payload_type
+        self.class.instance_variable_get :@payload_type
       end
 
       def push(*parts, context: Attributor::DEFAULT_ROOT_CONTEXT)

--- a/lib/praxis/types/multipart_array.rb
+++ b/lib/praxis/types/multipart_array.rb
@@ -101,7 +101,7 @@ module Praxis
                                                   filename_attribute: filename_attribute
                                                   )
         else
-          payload_attribute = compiler.define(name, payload_type || @payload_type, **opts)
+          payload_attribute = compiler.define(name, payload_type || self.payload_type, **opts)
           self.attributes[name] = compiler.define(name, Praxis::MultipartPart,
                                                   payload_attribute: payload_attribute,
                                                   filename_attribute: filename_attribute
@@ -179,7 +179,7 @@ module Praxis
               end
             end
           else
-            hash[:part_payload] = {type: @payload_type.describe(true)}
+            hash[:part_payload] = {type: payload_type.describe(true)}
           end
         end
         hash
@@ -231,7 +231,7 @@ module Praxis
       end
 
       def payload_type
-        self.class.instance_variable_get :@payload_type
+        self.class.payload_type
       end
 
       def push(*parts, context: Attributor::DEFAULT_ROOT_CONTEXT)

--- a/lib/praxis/types/multipart_array.rb
+++ b/lib/praxis/types/multipart_array.rb
@@ -51,7 +51,14 @@ module Praxis
         @name_type = Attributor.resolve_type type
       end
 
-      def self.payload_type(type=Attributor::Struct, **opts, &block)
+      def self.payload_type(type=nil, **opts, &block)
+        if type.nil?
+          if block_given?
+            type = Attributor::Struct
+          else
+            return @payload_type
+          end
+        end
         @payload_type = Attributor.resolve_type(type)
         @payload_attribute = Attributor::Attribute.new(@payload_type, **opts, &block)
         @part_attribute = nil

--- a/spec/praxis/types/multipart_array_spec.rb
+++ b/spec/praxis/types/multipart_array_spec.rb
@@ -105,6 +105,26 @@ describe Praxis::Types::MultipartArray do
     end
   end
 
+  context 'with simple payload_type block defined' do
+    let(:type) do
+      Class.new(Praxis::Types::MultipartArray) do
+        name_type String
+        payload_type do
+          attribute :attr, String
+        end
+      end
+    end
+
+    let(:json_payload) { {attr: 'value'}.to_json }
+    let(:body) { StringIO.new("--boundary\r\nContent-Disposition: form-data; name=blah\r\n\r\n#{json_payload}\r\n--boundary--") }
+    let(:content_type) { "multipart/form-data; boundary=boundary" }
+
+    it do
+      expect(payload.part('blah').payload.class.ancestors).to include(Attributor::Struct)
+      expect(payload.part('blah').payload.attr).to eq('value')
+    end
+  end
+
   context '.describe' do
     subject(:description) { type.describe(false) }
 

--- a/spec/praxis/types/multipart_array_spec.rb
+++ b/spec/praxis/types/multipart_array_spec.rb
@@ -102,6 +102,10 @@ describe Praxis::Types::MultipartArray do
 
     it do
       expect(payload.part('blah').payload['sub_hash']).to eq('key' => 'value')
+
+      # The "reader" functions should work
+      expect(payload.payload_type).to eq Attributor::Hash
+      expect(payload.class.payload_type).to eq Attributor::Hash
     end
   end
 
@@ -122,6 +126,10 @@ describe Praxis::Types::MultipartArray do
     it do
       expect(payload.part('blah').payload.class.ancestors).to include(Attributor::Struct)
       expect(payload.part('blah').payload.attr).to eq('value')
+
+      # The "reader" functions should work
+      expect(payload.payload_type).to eq Attributor::Struct
+      expect(payload.class.payload_type).to eq Attributor::Struct
     end
   end
 


### PR DESCRIPTION
This includes minor interface breakage: MultipartArray.payload_type can no longer be used as an accessor. (MultipartArray#payload_type still works though)
It would be possible to restore this functionality by checking if there are no args or blocks, but this seems unnecessary. =/ 