### PR TITLE
Set Attributor::AttributeResolver.current in RestfulDocGenerator.new

### DIFF
--- a/lib/praxis/restful_doc_generator.rb
+++ b/lib/praxis/restful_doc_generator.rb
@@ -134,6 +134,8 @@ module Praxis
       @doc_root_dir = File.join(@root_dir, API_DOCS_DIRNAME)
       @resources = []
 
+      Attributor::AttributeResolver.current = Attributor::AttributeResolver.new
+      
       remove_previous_doc_data
       load_resources
 


### PR DESCRIPTION
Needed to validate any attributes with the `required_if` option set.

Fixes #230