### PR TITLE
 Make action headers, params and payloads be required by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 * Added `Praxis::Handlers::WWWForm` for form-encoded data.
 * Added `Docs::Generator`, experimental new documentation generator. Use the `praxis:docs:experiments` rake task to generate. *Note*: not currently compatible with the documentation browser.
 * Added 'praxis.request_stage.execute' `ActiveSupport::Notifications` instrumentation to contorller action method execution in `RequestStages::Action#execute`.
-
+* Make action headers, params and payloads be required by default as it is probably what most people expect from it. To make any of those three definitions non-required, simply add the `:required` option as used in any other attribute definition. For example: `payload required: false do ...`
 
 ## 0.17.1
 

--- a/lib/praxis/action_definition.rb
+++ b/lib/praxis/action_definition.rb
@@ -103,7 +103,11 @@ module Praxis
     end
 
     def params(type=Attributor::Struct, **opts, &block)
-      return @params if !block && type == Attributor::Struct
+      return @params if !block && ( opts.nil? || opts.empty? ) && type == Attributor::Struct
+
+      unless( opts.key? :required )
+        opts[:required] = true # Make the payload required by default
+      end
 
       if @params
         unless type == Attributor::Struct && @params.type < Attributor::Struct
@@ -128,7 +132,11 @@ module Praxis
     end
 
     def payload(type=Attributor::Struct, **opts, &block)
-      return @payload if !block && type == Attributor::Struct
+      return @payload if !block && ( opts.nil? || opts.empty? ) && type == Attributor::Struct
+
+      unless( opts.key? :required )
+        opts[:required] = true # Make the payload required by default
+      end
 
       if @payload
         unless type == Attributor::Struct && @payload.type < Attributor::Struct
@@ -144,6 +152,11 @@ module Praxis
 
     def headers(type=nil, **opts, &block)
       return @headers unless block
+
+      unless( opts.key? :required )
+        opts[:required] = true # Make the payload required by default
+      end
+
       if @headers
         update_attribute(@headers, opts, block)
       else
@@ -227,7 +240,7 @@ module Praxis
         end
         hash[:traits] = traits if traits.any?
         # FIXME: change to :routes along with api browser
-        hash[:urls] = routes.collect do |route| 
+        hash[:urls] = routes.collect do |route|
           ActionDefinition.url_description(route: route, params: self.params, params_example: params_example)
         end.compact
         self.class.doc_decorations.each do |callback|
@@ -261,8 +274,8 @@ module Praxis
     end
 
     # Determine the content_type to report for a given example,
-    # using handler_name if possible. 
-    # 
+    # using handler_name if possible.
+    #
     # Considers any pre-defined set of values on the content_type attributge
     # of the headers.
     def derive_content_type(example, handler_name)
@@ -280,7 +293,7 @@ module Praxis
           return mti if mti.handler_name == handler_name
         end
 
-        # otherwise, pick the first 
+        # otherwise, pick the first
         pick = MediaTypeIdentifier.load(content_type_attribute.options[:values].first)
 
         # and return that one if it already corresponds to a registered handler
@@ -292,7 +305,7 @@ module Praxis
         end
       end
 
-      # generic default encoding 
+      # generic default encoding
       MediaTypeIdentifier.load("application/#{handler_name}")
     end
 

--- a/spec/praxis/action_definition_spec.rb
+++ b/spec/praxis/action_definition_spec.rb
@@ -100,6 +100,10 @@ describe Praxis::ActionDefinition do
   end
 
   describe '#params' do
+    it 'defaults to being required if omitted' do
+      expect(subject.params.options[:required]).to be(true)
+    end
+
     it 'merges in more params' do
       subject.params do
         attribute :more, Attributor::Integer
@@ -108,9 +112,22 @@ describe Praxis::ActionDefinition do
       attributes = subject.params.attributes.keys
       expect(attributes).to match_array([:one, :inherited, :more])
     end
+
+    it 'merges options (which allows overriding)' do
+      expect(subject.params.options[:required]).to be(true)
+
+      subject.params required: false
+
+      expect(subject.params.options[:required]).to be(false)
+    end
   end
 
   describe '#payload' do
+    it 'defaults to being required if omitted' do
+      expect(subject.payload.options[:required]).to be(true)
+    end
+
+
     it 'merges in more payload' do
       subject.payload do
         attribute :more, Attributor::Integer
@@ -119,6 +136,14 @@ describe Praxis::ActionDefinition do
       expect(subject.payload.attributes.keys).to match_array([
                                                                :two, :inherited, :more
       ])
+    end
+
+    it 'merges options (which allows overriding)' do
+      expect(subject.payload.options[:required]).to be(true)
+
+      subject.payload required: false
+
+      expect(subject.payload.options[:required]).to be(false)
     end
   end
 
@@ -131,6 +156,10 @@ describe Praxis::ActionDefinition do
       expect(subject.headers.type.options[:case_insensitive_load]).to be(true)
     end
 
+    it 'defaults to being required if omitted' do
+      expect(subject.headers.options[:required]).to be(true)
+    end
+
     it 'merges in more headers' do
       subject.headers do
         header "more"
@@ -138,6 +167,16 @@ describe Praxis::ActionDefinition do
 
       expected_array = ["X_REQUESTED_WITH", "Inherited", "more"]
       expect(subject.headers.attributes.keys).to match_array(expected_array)
+    end
+
+    it 'merges options (which allows overriding)' do
+      expect(subject.headers.options[:required]).to be(true)
+
+      subject.headers required: false do
+        header "even_more"
+      end
+
+      expect(subject.headers.options[:required]).to be(false)
     end
   end
 

--- a/spec/spec_app/design/resources/instances.rb
+++ b/spec/spec_app/design/resources/instances.rb
@@ -57,7 +57,7 @@ module ApiResources
         attribute :fail_filter, Attributor::Boolean, default: false
       end
 
-      payload do
+      payload required: false do
         attribute :something, String
         attribute :optional, String, default: "not given"
       end


### PR DESCRIPTION
This is probably what most people expect from it, so let's make it so.

 To make any of those three definitions non-required, simply add the `:required` option as used in any other attribute definition. For example: 

```
payload required: false do 
  attribute :foobar, String
end
```

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>