### PR TITLE
Controller Schema for a Controller missing:

### DIFF
--- a/lib/api_browser/app/js/controllers/type.js
+++ b/lib/api_browser/app/js/controllers/type.js
@@ -1,5 +1,5 @@
 ﻿app.controller('TypeCtrl', function ($scope, $stateParams, Documentation, normalizeAttributes) {
-  $scope.typeId = $stateParams.type || $scope.controller.media_type;
+  $scope.typeId = $stateParams.type || $scope.controller.media_type.id;
   $scope.apiVersion = $stateParams.version;
   $scope.controllers = [];
   $scope.views = [];

--- a/lib/api_browser/app/views/controller.html
+++ b/lib/api_browser/app/views/controller.html
@@ -42,8 +42,12 @@
     </div>
     </div>
   </div>
-  <div ng-if="controller.media_type" ng-controller="TypeCtrl">
+  <div ng-if="controller.media_type && controller.media_type.family != 'string'" ng-controller="TypeCtrl">
     <ng-include src="'views/type/details.html'" />
+  </div>
+  <div ng-if="controller.media_type && controller.media_type.family == 'string'">
+    <h2>Schema</h2>
+    <p ><b>Internet Media-type: {{ controller.media_type.identifier }}</b></p>
   </div>
   <h1>Actions</h1>
   <div ng-controller="ActionCtrl" ng-repeat="action in controller.actions">

--- a/lib/api_browser/app/views/type/details.html
+++ b/lib/api_browser/app/views/type/details.html
@@ -1,7 +1,7 @@
 ﻿<div class="row" ng-if="type">
   <div class="col-lg-12">
     <h2>Schema</h2>
-    <p ng-if="type.identifier"><b>Media-type: {{ type.identifier }}</b></p>
+    <p ng-if="type.identifier"><b>Media-type identifier: {{ type.identifier }}</b></p>
     <div ng-if="type.description" ng-bind-html="type.description | markdown"></div>
 
     <attribute-table attributes="type.attributes"></attribute-table>

--- a/lib/praxis/simple_media_type.rb
+++ b/lib/praxis/simple_media_type.rb
@@ -15,7 +15,7 @@ module Praxis
     end
 
     def describe(shallow=true)
-      {name: name, family: "string", id: id, identifier: identifier }
+      {name: name, family: "string", id: id, identifier: identifier}
     end
 
   end

--- a/lib/praxis/simple_media_type.rb
+++ b/lib/praxis/simple_media_type.rb
@@ -15,7 +15,7 @@ module Praxis
     end
 
     def describe(shallow=true)
-      {identifier: identifier}
+      {name: name, family: "string", id: id, identifier: identifier }
     end
 
   end

--- a/spec/praxis/response_definition_spec.rb
+++ b/spec/praxis/response_definition_spec.rb
@@ -522,7 +522,7 @@ describe Praxis::ResponseDefinition do
         subject(:examples) { payload[:examples] }
         its(['json', :content_type]) { 'application/vnd.acme.instance+json '}
         its(['xml', :content_type]) { 'application/vnd.acme.instance+xml' }
-        
+
         it 'properly encodes the example bodies' do
           json = Praxis::Application.instance.handlers['json'].parse(examples['json'][:body])
           xml = Praxis::Application.instance.handlers['xml'].parse(examples['xml'][:body])
@@ -556,7 +556,7 @@ describe Praxis::ResponseDefinition do
         end
 
         it{ should be_kind_of(::Hash) }
-        its([:payload]){ should == { identifier: 'foobar'} }
+        its([:payload]){ should ==  {id: 'Praxis-SimpleMediaType', name: 'Praxis::SimpleMediaType', family: 'string', identifier: 'foobar' } }
         its([:status]){ should == 200 }
       end
       context 'using a full response definition block' do
@@ -572,7 +572,7 @@ describe Praxis::ResponseDefinition do
         end
 
         it{ should be_kind_of(::Hash) }
-        its([:payload]) { should == { identifier: 'custom_media'} }
+        its([:payload]) { should == {id: 'Praxis-SimpleMediaType', name: 'Praxis::SimpleMediaType', family: 'string', identifier: 'custom_media'} }
         its([:status]) { should == 234 }
       end
     end


### PR DESCRIPTION
Fixed displaying of the default schema for a controller in the Doc Browser:
* Changed SimpleMediaType to be described in the same format of any other MediaType
* Changed doc browser to expect a hash defining the default media_type of a controller (containing a family and the identifier) amongst other.
* Added a simple display of the Schema that just shows an internet media_type identifier when the default one for the controller is a SimpleMediaType (i.e. string type)


Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>