### PR TITLE
Fix bug in MultipartArray file

### DIFF
--- a/lib/praxis/types/multipart_array.rb
+++ b/lib/praxis/types/multipart_array.rb
@@ -110,7 +110,7 @@ module Praxis
       end
 
       def self.file(name, payload_type=nil, filename: nil, **opts, &block)
-        self.part(name, payload_type=nil, filename: true, **opts, &block)
+        self.part(name, payload_type, filename: true, **opts, &block)
       end
 
       def self.load(value, context=Attributor::DEFAULT_ROOT_CONTEXT, content_type:nil)


### PR DESCRIPTION
Defining a part using the `file` syntax and passing in the `type` for it, it would still default to a `String` type.

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>