### PR TITLE
Handle loading empty MediaTypeIdentifier values:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 0.18.1
 
 * Fix Doc Browser regression, which would not show the schema in the Resource Definition home page.
+* Handle loading empty `MediaTypeIdentifier` values (to return `nil`)
 
 ## 0.18.0
 

--- a/lib/praxis/media_type_identifier.rb
+++ b/lib/praxis/media_type_identifier.rb
@@ -1,4 +1,5 @@
 require 'set'
+require 'active_support/core_ext/object/blank'
 
 module Praxis
   # Ruby object representation of an Internet Media Type Identifier as defined by
@@ -41,7 +42,9 @@ module Praxis
     # @return [MediaTypeIdentifier]
     # @see Attributor::Model#load
     def self.load(value, context=Attributor::DEFAULT_ROOT_CONTEXT, recurse: false, **options)
-      if value.is_a?(String)
+      case value
+      when String
+        return nil if value.blank?
         base, *parameters = value.split(PARAMETER_SEPARATOR)
         match = VALID_TYPE.match(base)
 
@@ -62,6 +65,8 @@ module Praxis
           obj.parameters = {}
         end
         obj
+      when nil
+        return nil
       else
         super
       end

--- a/spec/praxis/media_type_identifier_spec.rb
+++ b/spec/praxis/media_type_identifier_spec.rb
@@ -3,9 +3,23 @@ require "spec_helper"
 describe Praxis::MediaTypeIdentifier do
   let(:example) { 'application/ice-cream+sundae; nuts="true"; fudge="true"' }
 
-  subject { described_class.new(example) }
+  subject { described_class.load(example) }
 
   context '.load' do
+    context 'of nil values' do
+      let(:example) { nil }
+      it 'return nil' do
+        expect(subject).to be(nil)
+      end
+    end
+
+    context 'of empty string values' do
+      let(:example) { "" }
+      it 'returns nil' do
+        expect(subject).to be(nil)
+      end
+    end
+
     it 'parses type/subtype' do
       expect(subject.type).to eq('application')
       expect(subject.subtype).to eq('ice-cream')


### PR DESCRIPTION
* return a nil loaded value.

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>