### PR TITLE
Praxis::Collection.member_type sets the identifier

### DIFF
--- a/lib/praxis/collection.rb
+++ b/lib/praxis/collection.rb
@@ -10,10 +10,7 @@ module Praxis
       klass = super
 
       if type < Praxis::Types::MediaTypeCommon
-        unless type.identifier.nil?
-          klass.identifier(type.identifier + ';type=collection')
-        end
-
+        klass.member_type type
         type.const_set :Collection, klass
       else
         warn "DEPRECATION: Praxis::Collection.of() for non-MediaTypes will be unsupported in 1.0. Use Attributor::Collection.of() instead."
@@ -25,6 +22,7 @@ module Praxis
     def self.member_type(type=nil)
       unless type.nil?
         @member_type = type
+        self.identifier(type.identifier + ';type=collection') unless type.identifier.nil?
       end
 
       @member_type

--- a/spec/praxis/types/collection_spec.rb
+++ b/spec/praxis/types/collection_spec.rb
@@ -45,11 +45,18 @@ describe Praxis::Collection do
   end
 
   context '.member_type' do
-    its(:member_type){ should be(VolumeSnapshot) }
+    subject(:collection) do
+      class Team < Praxis::Collection
+        member_type Person
+      end
+      Team
+    end
+    its(:member_type){ should be(Person) }
     its(:member_attribute){ should be_kind_of(Attributor::Attribute) }
-    its('member_attribute.type'){ should be(VolumeSnapshot) }
+    its('member_attribute.type'){ should be(Person) }
+    its(:identifier) { should eq Person.identifier + "; type=collection" }
   end
-  
+
   context '.load' do
     let(:volume_data) do
       {
@@ -92,7 +99,7 @@ describe Praxis::Collection do
     context 'for members' do
       let(:volume_output) { example.render(view: :default) }
 
-      subject(:output) { volume_output[:snapshots] } 
+      subject(:output) { volume_output[:snapshots] }
 
       it { should eq(snapshots.collect(&:render)) }
     end
@@ -122,7 +129,7 @@ describe Praxis::Collection do
 
       let(:volume) { Volume.load(volume_data) }
       let(:snapshots) { volume.snapshots }
-      
+
       it 'validates' do
         expect(volume.validate).to be_empty
       end

--- a/spec/support/spec_media_types.rb
+++ b/spec/support/spec_media_types.rb
@@ -1,4 +1,6 @@
 class Person < Praxis::MediaType
+  identifier "application/vnd.acme.person"
+
   attributes do
     attribute :id, Integer
     attribute :name, String, example: /[:name:]/


### PR DESCRIPTION
Ensure the media-type identifier is always properly set
to the member’s identifier + “type=collection” regardless
of creating the collection using `.of` or through `.member_type` 

Fixes #244 

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>