### PR TITLE
Allow DocBrowser to accept collections as default media types

### DIFF
--- a/lib/praxis/action_definition.rb
+++ b/lib/praxis/action_definition.rb
@@ -95,7 +95,7 @@ module Praxis
     end
 
     def create_attribute(type=Attributor::Struct, **opts, &block)
-      unless opts[:reference]
+      unless opts.key?(:reference)
         opts[:reference] = @reference_media_type if @reference_media_type && block
       end
 

--- a/lib/praxis/restful_doc_generator.rb
+++ b/lib/praxis/restful_doc_generator.rb
@@ -33,7 +33,7 @@ module Praxis
         if the_type.member_attribute.nil?
           the_type = the_type.member_type
         else
-          the_type = the_type.member_attribute.type 
+          the_type = the_type.member_attribute.type
         end
       end
 
@@ -74,9 +74,6 @@ module Praxis
         # Collect reachable types from the media_type if any (plus itself)
         if @media_type && ! @media_type.is_a?(Praxis::SimpleMediaType)
           add_to_reachable RestfulDocGenerator.inspect_attributes(@media_type)
-          @media_type.attributes.each do |name, attr|
-            add_to_reachable RestfulDocGenerator.inspect_attributes(attr)
-          end
           @generated_example = @media_type.example(self.id)
         end
 
@@ -141,7 +138,7 @@ module Praxis
       @resources = []
 
       Attributor::AttributeResolver.current = Attributor::AttributeResolver.new
-      
+
       remove_previous_doc_data
       load_resources
 


### PR DESCRIPTION
* Removed unnecessary lines in the doc generator (that assumed a default media_type for a resource had attributes)
* Allow passing in the nil reference for params/payload in an action (to override the default media_type one)

Fixes #243 

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>