### PR TITLE
Utilise new docs format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,14 @@ resource definition.
   necessary to handle the request.
     * Note: This is primarily an internal extension used by the `MapperSelectors`
     and `Rendering` extensions, and is automatically included by them.
+* Doc browser now uses the new JSON format for responses.
+* Traits now get exposed in the doc browser.
+* Doc browser now displays examples for requesting actions.
+* Doc browser now correctly displays top-level collections in action payloads.
+* Doc browser has improved scrolling for the sidebar.
+* Doc browser displays more detailed HTML titles.
+* Doc browser has been switched back to having a separate page per action, however actions are now shown in the sidebar.
+* Doc browser will now display multiply nested resources in a proper hierarchy.
 
 ## 0.18.1
 

--- a/lib/api_browser/app/index.html
+++ b/lib/api_browser/app/index.html
@@ -1,16 +1,16 @@
 <!doctype html>
-<html>
+<html ng-app="DocBrowser">
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>API Browser</title>
+  <title ng-bind="subtitle ? title + ' – ' + subtitle : title">API Browser</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width">
   <!-- bower:css -->
   <!-- endbower -->
   <link rel="stylesheet" href="css/main.css">
 </head>
-<body ng-app="DocBrowser">
+<body>
   <div ui-view=""></div>
   <!-- build:js({.tmp,app}) scripts/praxis.js -->
   <!-- bower:js -->

--- a/lib/api_browser/app/js/app.js
+++ b/lib/api_browser/app/js/app.js
@@ -1,6 +1,9 @@
 var app = angular.module('PraxisDocBrowser', ['ui.router', 'ui.bootstrap', 'ngSanitize']);
 
-app.config(function ($stateProvider, $urlRouterProvider) {
+app.config(function ($stateProvider, $urlRouterProvider, $uiViewScrollProvider) {
+
+  $uiViewScrollProvider.useAnchorScroll();
+  
   $urlRouterProvider
     .otherwise('/');
 

--- a/lib/api_browser/app/js/app.js
+++ b/lib/api_browser/app/js/app.js
@@ -23,10 +23,14 @@ app.config(function ($stateProvider, $urlRouterProvider) {
       templateUrl: 'views/type.html',
       controller: 'TypeCtrl'
     })
-    .state('root.controller.action', {
-      url: '/:action'
+    .state('root.action', {
+      url: '/:version/controller/:controller/:action',
+      templateUrl: 'views/action.html',
+      controller: 'ActionCtrl'
     })
-    .state('root.controller.action.response', {
-      url: '/:response'
+    .state('root.trait', {
+      url: '/:version/trait/:trait',
+      templateUrl: 'views/trait.html',
+      controller: 'TraitCtrl'
     });
 });

--- a/lib/api_browser/app/js/controllers/action.js
+++ b/lib/api_browser/app/js/controllers/action.js
@@ -1,42 +1,47 @@
-app.controller('ActionCtrl', function($scope, $stateParams, Documentation, normalizeAttributes) {
+app.controller('ActionCtrl', function($scope, $stateParams, Documentation, normalizeAttributes, PageInfo) {
   $scope.controllerName = $stateParams.controller;
   $scope.actionName = $stateParams.action;
   $scope.apiVersion = $stateParams.version;
 
+  Documentation.controller($stateParams.version, $stateParams.controller).then(function(response) {
 
-  // Extract the example and attach it to each attribute
-  _.forEach(['headers', 'params', 'payload'], function(n) {
-    var set = $scope.action[n];
-    if (set) {
-      normalizeAttributes(set, set.type.attributes);
+    $scope.controller = response;
+    PageInfo.title = $scope.controller.display_name + ' » ' + $scope.actionName;
+    $scope.action = _.find(response.actions, function(action) { return action.name === $scope.actionName; });
+    if (!$scope.action) {
+      $scope.error = true;
+      return;
     }
-  });
+    // Extract the example and attach it to each attribute
+    _.forEach(['headers', 'params', 'payload'], function(n) {
+      var set = $scope.action[n];
+      if (set) {
+        normalizeAttributes(set, set.type.attributes);
+      }
+    });
 
-  $scope.responses = [];
-  _.forEach($scope.action.responses, function(response, name) {
-    response.name = name;
-    response.options = {
-      headers: response.headers
-    };
-
-    response.jsonExample = _.get(response, 'payload.examples.json');
-
-    $scope.responses.push(response);
-
-    if(response.parts_like) {
-      response.parts_like.isMultipart = true;
-      response.parts_like.options = {
-        headers: response.parts_like.headers
+    $scope.responses = [];
+    _.forEach($scope.action.responses, function(response, name) {
+      response.name = name;
+      response.options = {
+        headers: response.headers
       };
-      $scope.responses.push(response.parts_like);
-    }
+
+      response.numExamples = _.keys(_.get(response, 'payload.examples')).length;
+
+      $scope.responses.push(response);
+
+      if(response.parts_like) {
+        response.parts_like.isMultipart = true;
+        response.parts_like.options = {
+          headers: response.parts_like.headers
+        };
+        $scope.responses.push(response.parts_like);
+      }
+    });
   });
 
   $scope.hasResponses = function() {
     return $scope.action ? _.any($scope.action.responses) : false;
-  };
-
-  $scope.hasResponseExample = function(response) {
-    return response.jsonExample;
   };
 });

--- a/lib/api_browser/app/js/controllers/controller.js
+++ b/lib/api_browser/app/js/controllers/controller.js
@@ -1,39 +1,10 @@
-﻿app.controller('ControllerCtrl', function($scope, $stateParams, Documentation, $anchorScroll, $timeout) {
+﻿app.controller('ControllerCtrl', function($scope, $stateParams, Documentation) {
   $scope.controllerName = $stateParams.controller;
   $scope.apiVersion = $stateParams.version;
 
-  function scrollTo(id, time) {
-    if (angular.element('#' + id).length > 0) {
-      if (time > 20) {
-        $timeout(function() {
-          $anchorScroll.yOffset = angular.element('.header .navbar');
-          $anchorScroll(id);
-        }, 400);
-      } else {
-        $anchorScroll.yOffset = angular.element('.header .navbar');
-        $anchorScroll(id);
-      }
-    } else {
-      $timeout(function() {
-        scrollTo(id, 2 * time);
-      }, time);
-    }
-  }
-
-  Documentation.getController($stateParams.version, $stateParams.controller).then(function(response) {
-    $scope.controller = response.data;
+  Documentation.controller($stateParams.version, $stateParams.controller).then(function(response) {
+    $scope.controller = response;
   }, function() {
     $scope.error = true;
-  });
-
-  $scope.$on('$stateChangeSuccess', function(e, state, params) {
-    switch (state.name) {
-    case 'root.controller.action':
-      scrollTo('action-' + params.action, 10);
-      break;
-    case 'root.controller.action.response':
-      scrollTo('action-' + params.action + '-' + params.response);
-      break;
-    }
   });
 });

--- a/lib/api_browser/app/js/controllers/menu.js
+++ b/lib/api_browser/app/js/controllers/menu.js
@@ -2,53 +2,70 @@ app.controller('MenuCtrl', function($scope, $state, Documentation) {
   var parentLookup = {};
   $scope.versions = [];
   $scope.resources = {};
-  $scope.others = {};
+  $scope.schemas = {};
+  $scope.traits = {};
   $scope.selectedVersion = '';
   $scope.currentType = '';
   $scope.active = {};
 
-  var menuPromise = Documentation.getIndex().success(function(index) {
-    _.forEach(index, function(items, version) {
-      $scope.versions.push(version);
-      var resources = $scope.resources[version] = [];
-      var others = $scope.others[version] = [];
+  Documentation.versions().then(function(versions) {
+    $scope.versions = versions;
+    _.each(versions, function(version) {
+      Documentation.items(version).then(function(items) {
+        var resources = $scope.resources[version] = [];
+        var schemas = $scope.schemas[version] = [];
+        var traits = $scope.traits[version] = [];
+        var children = [];
+        _.each(items.resources, function(item, name) {
+          var link = { name: item.display_name, stateRef: '' };
 
-      _.forEach(items, function(item, name) {
-        var link = { name: name, stateRef: '' };
-        if (item.parent) {
-          link.parent = item.parent;
-        }
-        if (item.controller) {
-          parentLookup[item.controller] = link;
-          link.stateRef = $state.href('root.controller', { version: version, controller: item.controller });
-          link.typeName = item.controller;
-          resources.push(link);
-        } else if (item.media_type) {
-          link.stateRef = $state.href('root.type', { version: version, type: item.media_type });
-          link.typeName = item.media_type;
-          others.push(link);
-        } else if (item.kind) {
-          link.stateRef = $state.href('root.type', { version: version, type: item.kind });
-          link.typeName = item.kind;
-          others.push(link);
-        }
-      });
-      function getPath(r) {
-        if (r.parent) {
-          var path = getPath(parentLookup[r.parent]) + ':' + _.last(r.typeName.split('-'));
-          return path;
-        }
-        return _.last(r.typeName.split('-'));
-      }
-      $scope.resources[version] = _.map(_.sortBy(resources, getPath), function(r) {
-        r.grandfather = grandfatherType(r.typeName);
-        return r;
+          parentLookup[name] = link;
+          link.stateRef = $state.href('root.controller', { version: version, controller: name });
+          link.id = name;
+
+          link.actions = _.map(item.actions, function(action) {
+            var actionLink = { name: action.name, stateRef: '' };
+            parentLookup[name + '_action_' + action.name] = actionLink;
+            actionLink.parent = name;
+            actionLink.stateRef = $state.href('root.action', { version: version, controller: name, action: action.name });
+            actionLink.id = name + '_action_' + action.name;
+            actionLink.isAction = true;
+            actionLink.parentRef = link;
+            return actionLink;
+          });
+          link.childResources = [];
+          if (item.parent) {
+            link.parent = item.parent;
+            children.push(link);
+          } else {
+            resources.push(link);
+          }
+        });
+        _.each(items.schemas, function(item, name) {
+          var link = { name: item.display_name, stateRef: '' };
+          link.stateRef = $state.href('root.type', { version: version, type: item.id });
+          link.id = name;
+          schemas.push(link);
+        });
+        _.each(items.traits, function(item, name) {
+          var link = { name: name, stateRef: '' };
+          link.stateRef = $state.href('root.trait', { version: version, trait: name });
+          link.id = name;
+          traits.push(link);
+        });
+        _.each(children, function(link) {
+          if (parentLookup[link.parent]) {
+            link.parentRef = parentLookup[link.parent];
+            parentLookup[link.parent].childResources.push(link);
+          } else {
+            throw 'No parent resource found';
+          }
+        });
       });
     });
     var numeralVersions = _.filter($scope.versions, function(n) { return !isNaN(parseFloat(n)); })
                            .sort(function(a,b) { return parseFloat(b) - parseFloat(a); });
     $scope.selectedVersion = $state.params.version || numeralVersions[0] || $scope.versions[0];
-
   });
 
   $scope.select = function(version) {
@@ -59,25 +76,18 @@ app.controller('MenuCtrl', function($scope, $state, Documentation) {
     return $scope.resources[$scope.selectedVersion];
   };
 
-  $scope.availableOthers = function() {
-    return $scope.others[$scope.selectedVersion];
+  $scope.availableSchemas = function() {
+    return $scope.schemas[$scope.selectedVersion];
   };
 
-  function grandfatherType(id) {
-    var self = parentLookup[id];
-    if (self.parent) {
-      return grandfatherType(self.parent);
-    }
-    return id;
-  }
+  $scope.availableTraits = function() {
+    return $scope.traits[$scope.selectedVersion];
+  };
 
   $scope.$on('$stateChangeSuccess', function(e, state, params) {
     if (params.version) $scope.selectedVersion = params.version;
-    $scope.currentType = params.controller || params.type;
-    menuPromise.then(function() {
-      $scope.selectedGrandfatherType = params.controller && grandfatherType(params.controller);
-    });
-    $scope.active.resources = state.name !== 'root.type';
+    $scope.active.resources = state.name !== 'root.type' && state.name !== 'root.trait';
     $scope.active.schemas = state.name === 'root.type';
+    $scope.active.traits = state.name === 'root.trait';
   });
 });

--- a/lib/api_browser/app/js/controllers/trait.js
+++ b/lib/api_browser/app/js/controllers/trait.js
@@ -1,0 +1,10 @@
+﻿app.controller('TraitCtrl', function ($scope, $stateParams, Documentation) {
+  $scope.traitName = $stateParams.trait;
+  $scope.apiVersion = $stateParams.version;
+
+  Documentation.trait($stateParams.version, $scope.traitName).then(function(data) {
+    $scope.trait = data;
+  }, function() {
+    $scope.error = true;
+  });
+});

--- a/lib/api_browser/app/js/controllers/type.js
+++ b/lib/api_browser/app/js/controllers/type.js
@@ -4,16 +4,19 @@
   $scope.controllers = [];
   $scope.views = [];
 
-  Documentation.getType($stateParams.version, $scope.typeId).then(function(response) {
-    $scope.type = response.data;
-    $scope.views = _(response.data.views)
+  Documentation.type($stateParams.version, $scope.typeId).then(function(data) {
+    $scope.type = data;
+    $scope.views = _(data.views)
       .map(function(view, name) { return _.extend(view, { name: name }); })
       .select(function(view) { return view.name !== 'master'; })
       .value();
     normalizeAttributes($scope.type, $scope.type.attributes);
 
-    Documentation.getIndex().success(function(response) {
-      $scope.controllers = _.select(response[$scope.apiVersion], function(item) { return item.controller && item.media_type == $scope.type.name; });
+    Documentation.items($scope.apiVersion).then(function(response) {
+      $scope.controllers = _.select(response.resources, function(item, id) {
+        item.id = id;
+        return item.media_type.id == $scope.type.id;
+      });
     });
   }, function() {
     $scope.error = true;

--- a/lib/api_browser/app/js/directives/fixed_if_fits.js
+++ b/lib/api_browser/app/js/directives/fixed_if_fits.js
@@ -10,8 +10,15 @@ app.directive('fixedIfFits', function($timeout) {
         var height = _(element.find('.tab-content .tab-pane').get()).map(function(el) {
           return angular.element(el).height();
         }).max() + element.offset().top;
-        if (height < $(window).height()) {
-          element[0].style.width = element.width() + 'px';
+        var mq = window.matchMedia('(min-width: 768px)');
+        if (height < $(window).height() && mq.matches) {
+          var padding = 20;
+          element[0].style.width = (element.width() + padding) + 'px';
+          element[0].style.paddingRight = padding + 'px';
+          var navbarHeight = '' + ($('.navbar').height() || 60) + 'px';
+          element[0].style.height = 'calc(100vh - ' + navbarHeight + ')';
+          element[0].style.paddingBottom = '30px';
+          element[0].style.overflow = 'auto';
           element[0].style.position = 'fixed';
         }
       }, 100);

--- a/lib/api_browser/app/js/directives/menu_item.js
+++ b/lib/api_browser/app/js/directives/menu_item.js
@@ -1,0 +1,59 @@
+app.directive('menuItem', function($compile, $stateParams) {
+
+  function checkIfShouldShow(scope, params) {
+    var currentId = params.action ? params.controller + '_action_' + params.action : (params.controller || params.type || params.trait);
+    scope.isActive = scope.link.id === currentId;
+
+    function checkLink(link) {
+      if (link.id === currentId || link.parent === currentId) {
+        return true;
+      } else {
+        if (link.parentRef) {
+          var matches = function(r) { return r.id === currentId; };
+          if (!link.isAction) {
+            if ((link.parentRef.childResources || []).some(matches)) return true;
+          }
+          if ((link.parentRef.actions || []).some(matches)) return true;
+        }
+
+        return (link.childResources || []).some(checkLink) || (link.actions || []).some(checkLink);
+      }
+    }
+    scope.shouldShow = scope.toplevel || checkLink(scope.link);
+  }
+
+  function link(scope) {
+    scope.$on('$stateChangeSuccess', function(e, state, params) {
+      checkIfShouldShow(scope, params);
+    });
+    checkIfShouldShow(scope, $stateParams);
+  }
+
+  return {
+    restrict: 'E',
+    templateUrl: 'views/directives/menu_item.html',
+    scope: {
+      link: '=',
+      toplevel: '='
+    },
+    // hackery to make a recursive directive
+    compile: function(element) {
+      var contents = element.contents().remove();
+      var compiledContents;
+      return {
+        post: function(scope, element){
+          // Compile the contents
+          if(!compiledContents) {
+            compiledContents = $compile(contents);
+          }
+          // Re-add the compiled contents to the element
+          compiledContents(scope, function(clone) {
+            element.append(clone);
+          });
+
+          link(scope, element);
+        }
+      };
+    }
+  };
+});

--- a/lib/api_browser/app/js/directives/readable_list.js
+++ b/lib/api_browser/app/js/directives/readable_list.js
@@ -1,0 +1,87 @@
+app.factory('Repeater', function() {
+  function Repeater(expression) {
+    var match = expression.match(/^\s*([\s\S]+?)\s+in\s+([\s\S]+?)(?:\s+as\s+([\s\S]+?))?(?:\s+track\s+by\s+([\s\S]+?))?\s*$/);
+
+    var lhs = match[1];
+    this.rhs = match[2];
+    this.aliasAs = match[3];
+    this.trackByExp = match[4];
+
+    match = lhs.match(/^(?:(\s*[\$\w]+)|\(\s*([\$\w]+)\s*,\s*([\$\w]+)\s*\))$/);
+
+    this.valueIdentifier = match[3] || match[1];
+    this.keyIdentifier = match[2];
+  }
+
+  Repeater.prototype.$watch = function(fn) {
+    this.$scope.$watchCollection(this.rhs, fn);
+  };
+
+  Repeater.prototype.$transclude = function(length, value, key, index, fn) {
+    var self = this;
+    self._transclude(function(clone, scope) {
+      scope[self.valueIdentifier] = value;
+      if (self.keyIdentifier) scope[self.keyIdentifier] = key;
+      scope.$index = index;
+      scope.$first = (index === 0);
+      scope.$last = (index === (length - 1));
+      scope.$middle = !(scope.$first || scope.$last);
+      // jshint bitwise: false
+      scope.$odd = !(scope.$even = (index&1) === 0);
+      // jshint bitwise: true
+      fn(clone, scope);
+    });
+  };
+
+  return {
+    compile: function(repeatAttr, linkFn) {
+      return function(element, attrs) {
+        var expression = attrs[repeatAttr];
+        var repeater = new Repeater(expression);
+        return function($scope, $element, $attr, ctrl, $transclude) {
+          repeater._transclude = $transclude;
+          repeater.$scope = $scope;
+          linkFn($scope, $element, $attr, ctrl, repeater);
+        };
+      };
+    }
+  };
+});
+app.directive('readableList', function(Repeater) {
+
+  return {
+    restrict: 'E',
+    transclude: true,
+    compile: Repeater.compile('repeat', function($scope, $element, $attr, ctrl, $repeat) {
+      $repeat.$watch(function(inputList) {
+        $element.empty();
+        if (inputList.length == 1) {
+          $repeat.$transclude(1, inputList[0], null, 0, function(clone) {
+            $element.append(clone);
+          });
+        } else {
+          var finalJoin = ' and ';
+
+          var join = ', ',
+              arr = inputList.slice(0),
+              last = arr.pop(),
+              beforeLast = arr.pop();
+
+          _.each(arr, function(data, index) {
+            $repeat.$transclude(inputList.length, data, null, index, function(clone) {
+              $element.append(clone);
+              $element.append(document.createTextNode(join));
+            });
+          });
+          $repeat.$transclude(inputList.length, beforeLast, null, inputList.length - 2, function(clone) {
+            $element.append(clone);
+            $element.append(document.createTextNode(finalJoin));
+          });
+          $repeat.$transclude(inputList.length, last, null, inputList.length - 1, function(clone) {
+            $element.append(clone);
+          });
+        }
+      });
+    })
+  };
+});

--- a/lib/api_browser/app/js/directives/url.js
+++ b/lib/api_browser/app/js/directives/url.js
@@ -1,0 +1,16 @@
+/**
+ * This directive is responsible to render a URL for an action
+ */
+app.directive('url', function() {
+  return {
+    restrict: 'EA',
+    scope: {
+      action: '=',
+      example: '@'
+    },
+    templateUrl: 'views/directives/url.html',
+    link: function(scope, element, attrs) {
+      scope.showExample = scope.example == 'example' || scope.example == 'true' || 'example' in attrs;
+    }
+  };
+});

--- a/lib/api_browser/app/js/factories/Configuration.js
+++ b/lib/api_browser/app/js/factories/Configuration.js
@@ -7,7 +7,6 @@ app.provider('Configuration', function() {
   this.$get = function() {
     return this;
   };
-}).run(function(Configuration, $rootScope, $document) {
+}).run(function(Configuration, $rootScope) {
   _.extend($rootScope, _.omit(Configuration, '$get'));
-  $document[0].title = Configuration.title;
 });

--- a/lib/api_browser/app/js/factories/Documentation.js
+++ b/lib/api_browser/app/js/factories/Documentation.js
@@ -1,13 +1,55 @@
-﻿app.factory('Documentation', function($http) {
+/**
+ * This service gives access to the documentation metadata
+ */
+app.factory('Documentation', function($http, $q) {
+  var versions = $q.when($http.get('api/index-new.json', { cache: true }).then(function(data) {
+    return $q.all(_.map(data.data.versions, function(version) {
+      return $http.get('api/' + version + '.json', {cache: true}).then(function(versionData) {
+        return [version, versionData.data];
+      });
+    })).then(_.zipObject);
+  }));
+
   return {
-    getIndex: function() {
-      return $http.get('api/index.json', { cache: true });
+    /**
+     * Returns an array of version strings
+     */
+    versions: function() {
+      return versions.then(_.keys);
     },
-    getController: function(version, name) {
-      return $http.get('api/' + version + '/resources/' + name + '.json', { cache: true });
+    /**
+     * Returns a list of controllers and types, useful for generating navigation
+     */
+    items: function(version) {
+      return versions.then(function(v) { return v[version]; });
     },
-    getType: function(version, name) {
-      return $http.get('api/' + version + '/types/' + name + '.json', { cache: true });
+    /**
+     * Returns description of a controller
+     */
+    controller: function(version, name) {
+      return this.items(version).then(function(v) {
+        var controller = v.resources[name];
+        controller.id = name;
+        return controller;
+      });
+    },
+
+    /**
+     * Returns a description of a type
+     */
+    type: function(version, name) {
+      return versions.then(function(v) {
+        return v[version].schemas[name];
+      });
+    },
+
+    /**
+     * Returns a description of a trait
+     */
+    trait: function(version, name) {
+      return versions.then(function(v) {
+        return v[version].traits[name];
+      });
     }
   };
 });

--- a/lib/api_browser/app/js/factories/PageInfo.js
+++ b/lib/api_browser/app/js/factories/PageInfo.js
@@ -1,0 +1,9 @@
+app.service('PageInfo', function($rootScope) {
+  this.title = null;
+  var self = this;
+  $rootScope.$watch(function() {
+    return self.title;
+  }, function() {
+    $rootScope.subtitle = self.title;
+  });
+});

--- a/lib/api_browser/app/js/factories/normalize_attributes.js
+++ b/lib/api_browser/app/js/factories/normalize_attributes.js
@@ -2,11 +2,10 @@ app.factory('normalizeAttributes', function() {
   function normalize(type, attributes, parent) {
     _.forEach(attributes, function(attribute, name) {
       var path = parent.concat([name]);
-      var example = JSON.stringify(_.get(type.example, path), null, 2);
       if (!attribute.options) attribute.options = {};
-      if (example) attribute.options.example = example;
       if (attribute.values != null) attribute.options.values = attribute.values;
       if (attribute.default != null) attribute.options.default = attribute.default;
+      if (attribute.example != null) attribute.options.example = attribute.example;
       if (attribute.type && attribute.type.attributes) {
         normalize(type, attribute.type.attributes, path);
       }

--- a/lib/api_browser/app/js/factories/template_for.js
+++ b/lib/api_browser/app/js/factories/template_for.js
@@ -36,6 +36,8 @@ app.provider('templateFor', function() {
       switch ($family) {
         case 'hash':
           return 'views/types/standalone/struct.html';
+        case 'array':
+          return 'views/types/standalone/array.html';
         default:
           return 'views/types/standalone/default.html';
       }

--- a/lib/api_browser/app/js/factories/template_for.js
+++ b/lib/api_browser/app/js/factories/template_for.js
@@ -62,14 +62,14 @@ app.provider('templateFor', function() {
   this.register(function labelResolver($typeDefinition, $requestedTemplate, primitives) {
     'ngInject';
     if ($requestedTemplate === 'label') {
-      if (_.contains(primitives, $typeDefinition.name)) {
-        return 'views/types/label/primitive.html';
-      } else if ( $typeDefinition.member_attribute !== undefined ) {
-        if ( _.contains(primitives, $typeDefinition.member_attribute.type.name)){
+      if ( $typeDefinition.member_attribute !== undefined) {
+        if ($typeDefinition.member_attribute.anonymous || _.contains(primitives, $typeDefinition.name)) {
           return 'views/types/label/primitive_collection.html';
         } else{
           return 'views/types/label/type_collection.html';
         }
+      } else if ($typeDefinition.anonymous || _.contains(primitives, $typeDefinition.name)) {
+        return 'views/types/label/primitive.html';
       } else if ($typeDefinition.link_to) {
         return 'views/types/label/link.html';
       }

--- a/lib/api_browser/app/sass/modules/_sidebar.scss
+++ b/lib/api_browser/app/sass/modules/_sidebar.scss
@@ -3,9 +3,6 @@
 // ------------------------------
 
 .sidebar {
-  @media (min-width: $screen-sm-min) {
-    width: 160px;
-  }
   @media (min-width: $screen-lg-min) {
     width: 250px;
   }
@@ -20,25 +17,57 @@
 }
 
 .sidebar {
+  .open .dropdown-menu {
+    margin-left: 15px;
+  }
   .list-group {
     margin-bottom: 0;
     margin-top: 0;
-  }
-  .list-group-item {
-    border-width: 1px 0;
-    word-break: break-word;
-    &:first-of-type {
+    & > menu-item:first-of-type > .menu-item {
       border-radius: 0;
       border-top: 0 none;
     }
-    &:last-of-type {
-      border-bottom: 0 none;
+  }
+  .action {
+    background: $table-bg-accent;
+  }
+  .menu-item {
+    position: relative;
+    display: block;
+    // Place the border on the list items and negative margin up for better styling
+    margin-bottom: -1px;
+    background-color: $list-group-bg;
+    border: 1px solid $list-group-border;
+    border-width: 1px 0;
+    word-break: break-word;
+    a {
+      display: block;
+      padding: 10px 15px;
+      // Hover state
+      &:hover,
+      &:focus {
+        text-decoration: none;
+        background-color: $list-group-hover-bg;
+      }
+
+      // Active class on item itself, not parent
+      &.active,
+      &.active:hover,
+      &.active:focus {
+        z-index: 2; // Place active items above their siblings for proper border styling
+        color: $list-group-active-color;
+        background-color: $list-group-active-bg;
+        border-color: $list-group-active-border;
+      }
     }
-    &.child-resource {
-      padding-left: 2.5em;
-    }
-    &.group-selected {
-      border-left: 2px solid $link-color;
+    .menu-item {
+      a { padding: 10px 2.5em; }
+      .menu-item {
+        a { padding: 10px 3.5em; }
+        .menu-item {
+          a { padding: 10px 4.5em; }
+        }
+      }
     }
   }
 }
@@ -73,6 +102,7 @@
       a {
         border-bottom: 0;
         font-size: 12px;
+        padding: 10px 5px;
         &:hover {
           background-color: #fff;
           border-color: transparent;

--- a/lib/api_browser/app/sass/modules/_sidebar.scss
+++ b/lib/api_browser/app/sass/modules/_sidebar.scss
@@ -30,6 +30,8 @@
   }
   .action {
     background: $table-bg-accent;
+    font-size: 11px;
+    font-weight: bolder;
   }
   .menu-item {
     position: relative;
@@ -58,14 +60,21 @@
         color: $list-group-active-color;
         background-color: $list-group-active-bg;
         border-color: $list-group-active-border;
+        font-weight: bolder;
       }
     }
     .menu-item {
-      a { padding: 10px 2.5em; }
+      a.action { padding: 10px 2.5rem; }
+      a.main { padding: 10px 2rem; }
+      a.main::before {
+        content: "↳"
+      }
       .menu-item {
-        a { padding: 10px 3.5em; }
+        a.action { padding: 10px 3.5rem; }
+        a.main { padding: 10px 3rem; }
         .menu-item {
-          a { padding: 10px 4.5em; }
+          a.action { padding: 10px 4.5rem; }
+          a.main { padding: 10px 4rem; }
         }
       }
     }

--- a/lib/api_browser/app/views/action.html
+++ b/lib/api_browser/app/views/action.html
@@ -43,6 +43,11 @@
       <div ng-if="!action.payload.examples">
         <h4>URL</h4>
         <url action="action" example></url>
+        <div ng-if="action.headers.example">
+          <h4>Headers</h4>
+          <pre><span ng-repeat="(header, value) in action.headers.example">{{header}}: {{value}}
+</span></pre>
+        </div>
       </div>
       <tabset ng-if="action.payload.examples">
         <tab ng-repeat="(type, example) in action.payload.examples" heading="{{type}}">
@@ -50,6 +55,11 @@
           <url action="action" example></url>
           <h4>Content-Type</h4>
           <p><code>{{example.content_type}}</code></p>
+          <div ng-if="action.headers.example">
+            <h4>Headers</h4>
+            <pre><span ng-repeat="(header, value) in action.headers.example">{{header}}: {{value}}
+</span></pre>
+          </div>
           <h4>Request body</h4>
           <pre>{{ example.body }}</pre>
         </tab>
@@ -73,7 +83,7 @@
               </div>
               <div ng-if="response.payload.id">
                 <h5>Media Type</h5>
-                <p><a ui-sref="root.type({version: apiVersion, type: response.payload.id})">{{response.payload.name}}</a></p>
+                <p><type-placeholder template="label" type="response.payload"></type-placeholder></p>
               </div>
             </div>
             <div class="col-md-8">

--- a/lib/api_browser/app/views/action.html
+++ b/lib/api_browser/app/views/action.html
@@ -4,99 +4,94 @@
 <div ng-if="action">
   <div class="row">
     <div class="col-lg-12">
-      <h2>
-        {{ action.name }}
-      </h2>
-      <p ng-repeat="url in action.urls">
-        <span class="label label-default verb" ng-class="url.verb | lowercase">{{ url.verb }}</span> <b>{{ url.path }}</b>
-      </p>
+      <h1>
+        <a ui-sref="root.controller({version: apiVersion, controller: controller.id})">{{controller.display_name}}</a> » {{ action.name }}
+      </h1>
+      <url action="action"></url>
       <p ng-bind-html="action.description | markdown"></p>
+      <p class="traits" ng-if="action.traits.length > 0">
+        This action is&nbsp;
+        <readable-list repeat="trait in action.traits"><a ui-sref="root.trait({version: apiVersion, trait: trait})">{{trait}}</a></readable-list>.
+      </p>
     </div>
   </div>
 
   <div class="row" ng-if="action.headers.type.attributes">
     <div class="col-lg-12">
-      <h3>Request Headers</h3>
+      <h2>Request Headers</h2>
       <type-placeholder details="action.headers.type.attributes" type="action.headers.type" template="standalone"></type-placeholder>
     </div>
   </div>
 
   <div class="row" ng-if="action.params.type.attributes">
     <div class="col-lg-12">
-      <h3>Request Parameters</h3>
+      <h2>Request Parameters</h2>
       <type-placeholder details="action.params.type.attributes" type="action.params.type" template="standalone"></type-placeholder>
     </div>
   </div>
 
   <div class="row" ng-if="action.payload.type">
     <div class="col-lg-12">
-      <h3>Request Body</h3>
+      <h2>Request Body</h2>
       <type-placeholder type="action.payload.type" template="standalone" details="action.payload.type.attributes"></type-placeholder>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-12">
+      <h2>Request Example</h2>
+      <div ng-if="!action.payload.examples">
+        <h4>URL</h4>
+        <url action="action" example></url>
+      </div>
+      <tabset ng-if="action.payload.examples">
+        <tab ng-repeat="(type, example) in action.payload.examples" heading="{{type}}">
+          <h4>URL</h4>
+          <url action="action" example></url>
+          <h4>Content-Type</h4>
+          <p><code>{{example.content_type}}</code></p>
+          <h4>Request body</h4>
+          <pre>{{ example.body }}</pre>
+        </tab>
+      </tabset>
     </div>
   </div>
 
   <div class="row" ng-if="hasResponses()">
     <div class="col-lg-12">
-      <h3>Responses</h3>
-      <div class="table-responsive">
-        <table class="table table-striped table-bordered">
-          <thead>
-            <tr>
-              <th>Code</th>
-              <th>Name</th>
-              <th>Media Type</th>
-              <th>Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr ng-repeat="response in responses">
-              <td>
-                <span ng-if="response.isMultipart">
-                  <em>Parts Like:</em>
-                </span>
-                <a ng-if="hasResponseExample(response)" ui-sref="root.controller.action.response({response: response.name, action: action.name, controller: controllerName, version: apiVersion})">
-                  {{response.status}}
-                </a>
-                <span ng-if="!hasResponseExample(response)">
-                  {{response.status}}
-                </span>
-              </td>
-              <td>
-                <a ng-if="hasResponseExample(response)" ui-sref="root.controller.action.response({response: response.name, action: action.name, controller: controllerName, version: apiVersion})">
-                  {{response.name}}
-                </a>
-                <span ng-if="!hasResponseExample(response)">
-                  {{response.name}}
-                </span>
-              </td>
-              <td>
-                {{response.media_type.id || response.media_type.identifier}}
-              </td>
-              <td>
-                <attribute-description attribute="response"></attribute-description>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-
-    <div class="col-lg-12" ng-repeat="response in responses | filter: hasResponseExample" id="action-{{action.name}}-{{response.name}}">
-      <h4>Response example: {{ response.name }}</h4>
-
-      <div class="row">
-        <div class="col-md-4">
-          <h5>Status</h5>
-          <p>{{ response.status }}</p>
-          <h5>Content-Type</h5>
-          <p>{{ response.jsonExample.content_type }}</p>
-        </div>
-        <div class="col-md-8">
-          <h5>Example</h5>
-          <pre>{{ response.jsonExample.body }}</pre>
+      <h2>Responses</h2>
+      <div class="panel panel-default" ng-repeat="response in responses">
+        <div class="panel-heading"><h4 class="panel-title">{{response.name}}</h4></div>
+        <div class="panel-body">
+          <div class="row">
+            <div class="col-md-4">
+              <h5>Status</h5>
+              <p>{{ response.status }}</p>
+              <div ng-if="response.examples.json">
+                <h5>Content-Type</h5>
+                <p>{{ response.examples.json.content_type }}</p>
+              </div>
+              <div ng-if="response.payload.id">
+                <h5>Media Type</h5>
+                <p><a ui-sref="root.type({version: apiVersion, type: response.payload.id})">{{response.payload.name}}</a></p>
+              </div>
+            </div>
+            <div class="col-md-8">
+              <div ng-if="response.payload.examples">
+                <h5>Response Example</h5>
+                <tabset ng-if="numExamples > 1">
+                  <tab ng-repeat="(type, example) in response.payload.examples" heading="{{type}}">
+                    <pre>{{ example.body }}</pre>
+                  </tab>
+                </tabset>
+                <div ng-if="response.numExamples == 1">
+                  <pre ng-repeat="(type, example) in response.payload.examples">{{ example.body }}</pre>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
   </div>
 </div>
-<hr class="action-divider" />

--- a/lib/api_browser/app/views/action.html
+++ b/lib/api_browser/app/views/action.html
@@ -53,11 +53,10 @@
         <tab ng-repeat="(type, example) in action.payload.examples" heading="{{type}}">
           <h4>URL</h4>
           <url action="action" example></url>
-          <h4>Content-Type</h4>
-          <p><code>{{example.content_type}}</code></p>
           <div ng-if="action.headers.example">
             <h4>Headers</h4>
-            <pre><span ng-repeat="(header, value) in action.headers.example">{{header}}: {{value}}
+            <pre><span ng-if="example.content_type">Content-Type: {{example.content_type}}
+</span><span ng-repeat="(header, value) in action.headers.example">{{header}}: {{value}}
 </span></pre>
           </div>
           <h4>Request body</h4>

--- a/lib/api_browser/app/views/controller.html
+++ b/lib/api_browser/app/views/controller.html
@@ -7,7 +7,13 @@
       <h1 class="page-header">
         {{ controller.name | resourceName }}
       </h1>
-       <p ng-bind-html="controller.description | markdown"></p>
+
+      <p ng-bind-html="controller.description | markdown"></p>
+
+      <p class="traits" ng-if="controller.traits.length > 0">
+        This resource is&nbsp;
+        <readable-list repeat="trait in controller.traits"><a ui-sref="root.trait({version: apiVersion, trait: trait})">{{trait}}</a></readable-list>.
+      </p>
     </div>
   </div>
   <div class="row" ng-if="controller.actions.length">
@@ -25,13 +31,10 @@
         <tbody>
           <tr ng-repeat="action in controller.actions">
             <td>
-              <a ui-sref="root.controller.action({action: action.name, controller: controllerName, version: apiVersion})">{{ action.name }}</a>
+              <a ui-sref="root.action({action: action.name, controller: controllerName, version: apiVersion})">{{ action.name }}</a>
             </td>
             <td>
-              <div ng-repeat="url in action.urls">
-                <div class="label label-default verb" ng-class="url.verb | lowercase">{{ url.verb }}</div>
-                <strong>{{ url.path }}</strong>
-              </div>
+              <url action="action"></url>
             </td>
             <td style="font-size: 110%;">
               <p ng-bind-html="action.description | markdown"></p>
@@ -48,9 +51,5 @@
   <div ng-if="controller.media_type && controller.media_type.family == 'string'">
     <h2>Schema</h2>
     <p ><b>Internet Media-type: {{ controller.media_type.identifier }}</b></p>
-  </div>
-  <h1>Actions</h1>
-  <div ng-controller="ActionCtrl" ng-repeat="action in controller.actions">
-    <div id="action-{{action.name}}" ng-include="'views/action.html'"></div>
   </div>
 </div>

--- a/lib/api_browser/app/views/directives/menu_item.html
+++ b/lib/api_browser/app/views/directives/menu_item.html
@@ -1,6 +1,6 @@
 <div class="menu-item" ng-if="shouldShow">
   <a href="{{link.stateRef}}"
-     ng-class="{active: isActive, 'child-resource': link.parent, 'action': link.isAction}">
+     ng-class="{active: isActive, 'child-resource': link.parent, 'action': link.isAction, 'main': !link.isAction}">
     {{ link.name }}
   </a>
   <menu-item ng-repeat="action in link.actions" link="action"></menu-item>

--- a/lib/api_browser/app/views/directives/menu_item.html
+++ b/lib/api_browser/app/views/directives/menu_item.html
@@ -1,0 +1,8 @@
+<div class="menu-item" ng-if="shouldShow">
+  <a href="{{link.stateRef}}"
+     ng-class="{active: isActive, 'child-resource': link.parent, 'action': link.isAction}">
+    {{ link.name }}
+  </a>
+  <menu-item ng-repeat="action in link.actions" link="action"></menu-item>
+  <menu-item ng-repeat="resource in link.childResources" link="resource"></menu-item>
+</div>

--- a/lib/api_browser/app/views/directives/url.html
+++ b/lib/api_browser/app/views/directives/url.html
@@ -1,0 +1,3 @@
+<p ng-repeat="url in action.urls">
+  <span class="label label-default verb" ng-class="url.verb | lowercase">{{ url.verb }}</span>&nbsp;<b>{{ showExample ?  url.example : url.path }}</b>
+</p>

--- a/lib/api_browser/app/views/layout.html
+++ b/lib/api_browser/app/views/layout.html
@@ -3,6 +3,6 @@
 <div class="container" ng-cloak>
   <div class="row">
     <div class="col-sm-4 col-md-3" ng-controller="MenuCtrl" ng-include="'views/menu.html'"></div>
-    <div class="col-sm-8 col-md-9" ui-view=""></div>
+    <div class="col-sm-8 col-md-9" ui-view="" autoscroll="true"></div>
   </div>
 </div>

--- a/lib/api_browser/app/views/layout.html
+++ b/lib/api_browser/app/views/layout.html
@@ -2,7 +2,7 @@
 
 <div class="container" ng-cloak>
   <div class="row">
-    <div class="col-sm-3" ng-controller="MenuCtrl" ng-include="'views/menu.html'"></div>
-    <div class="col-sm-9" ui-view=""></div>
+    <div class="col-sm-4 col-md-3" ng-controller="MenuCtrl" ng-include="'views/menu.html'"></div>
+    <div class="col-sm-8 col-md-9" ui-view=""></div>
   </div>
 </div>

--- a/lib/api_browser/app/views/menu.html
+++ b/lib/api_browser/app/views/menu.html
@@ -6,7 +6,7 @@
           <button type="button" class="btn btn-success" dropdown-toggle ng-disabled="disabled">
             {{:: versionLabel}}: {{selectedVersion}} <span class="caret"></span>
           </button>
-          <ul class="dropdown-menu col-sm-12" role="menu">
+          <ul class="dropdown-menu" role="menu">
             <li ng-repeat="version in versions">
               <a ng-click="select(version)" dropdown-toggle>{{version}}</a>
             </li>
@@ -23,23 +23,17 @@
       <tabset justified="true" class="tab-list-group">
         <tab heading="Resources" active="active.resources">
           <div class="list-group">
-            <a ng-repeat="link in availableResources()"
-               href="{{link.stateRef}}"
-               class="list-group-item"
-               ng-hide="expandChildren && link.parent && selectedGrandfatherType != link.grandfather"
-               ng-class="{active: link.typeName == currentType, 'child-resource': link.parent, 'group-selected': selectedGrandfatherType ==  link.grandfather}">
-              {{ link.name }}
-            </a>
+            <menu-item ng-repeat="link in availableResources() | orderBy: 'name'" link="link" toplevel="true"></menu-item>
           </div>
         </tab>
         <tab heading="Schemas" active="active.schemas">
           <div class="list-group">
-            <a ng-repeat="link in availableOthers()"
-               href="{{link.stateRef}}"
-               class="list-group-item"
-               ng-class="{active: link.typeName == currentType}">
-              {{ link.name }}
-            </a>
+            <menu-item ng-repeat="link in availableSchemas() | orderBy: 'name'" link="link" toplevel="true"></menu-item>
+          </div>
+        </tab>
+        <tab heading="Traits" active="active.traits" ng-if="availableTraits().length > 0">
+          <div class="list-group">
+            <menu-item ng-repeat="link in availableTraits() | orderBy: 'name'" link="link" toplevel="true"></menu-item>
           </div>
         </tab>
       </tabset>

--- a/lib/api_browser/app/views/navbar.html
+++ b/lib/api_browser/app/views/navbar.html
@@ -2,7 +2,7 @@
   <div class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="container">
       <div class="navbar-header">
-        <a class="navbar-brand" href="#">{{:: title}}</a>
+        <a class="navbar-brand" href="#/">{{:: title}}</a>
       </div>
     </div>
   </div>

--- a/lib/api_browser/app/views/trait.html
+++ b/lib/api_browser/app/views/trait.html
@@ -1,0 +1,13 @@
+<div ng-if="error" class="alert alert-danger">
+  <p>The requested trait could not be found.</p>
+</div>
+<div ng-if="trait">
+  <div class="row">
+    <div class="col-lg-12">
+      <h1>
+        {{ traitName | resourceName }}
+      </h1>
+    </div>
+  </div>
+  <div ng-if="trait.description" ng-bind-html="trait.description | markdown"></div>
+</div>

--- a/lib/api_browser/app/views/type.html
+++ b/lib/api_browser/app/views/type.html
@@ -16,7 +16,7 @@
       <h3>Served by</h3>
       <ul>
         <li ng-repeat="controller in controllers">
-          <a ui-sref="root.controller({version: apiVersion, controller: controller.controller})">{{ controller.name | resourceName }}</a>
+          <a ui-sref="root.controller({version: apiVersion, controller: controller.id})">{{ controller.name | resourceName }}</a>
         </li>
       </ul>
     </div>

--- a/lib/api_browser/app/views/type/details.html
+++ b/lib/api_browser/app/views/type/details.html
@@ -16,7 +16,7 @@
           <div class="col-md-4">
             <h4>Attributes</h4>
             <ul>
-              <li ng-repeat="(name,value) in view.attributes">{{name}} <span class="label label-default" ng-if="value.view">rendered with {{value.view}} view</span></li>
+              <li ng-repeat="(name,value) in view.attributes">{{name}} <span class="label label-default" ng-if="value.view">{{value.view}} view</span></li>
             </ul>
           </div>
           <div class="col-md-8">

--- a/lib/api_browser/app/views/types/label/primitive.html
+++ b/lib/api_browser/app/views/types/label/primitive.html
@@ -1,1 +1,1 @@
-<span>{{type.name}}</span>
+<span>{{type.name | resourceName}}</span>

--- a/lib/api_browser/app/views/types/standalone/array.html
+++ b/lib/api_browser/app/views/types/standalone/array.html
@@ -1,0 +1,3 @@
+<p>A Collection of:</p>
+
+<type-placeholder type="type.member_attribute.type" template="standalone" details="type.member_attribute.type.attributes"></type-placeholder>

--- a/lib/praxis/action_definition.rb
+++ b/lib/praxis/action_definition.rb
@@ -253,7 +253,7 @@ module Praxis
       output = headers.describe(example: example)
       required_headers = self.headers.attributes.select{|k,attr| attr.options && attr.options[:required] == true  }
       output[:example] = required_headers.each_with_object({}) do | (name, attr), hash |
-        hash[name] = example[name]
+        hash[name] = example[name].to_s # Some simple types (like Boolean) can be used as header values, but must convert back to s
       end
       output
     end

--- a/lib/praxis/collection.rb
+++ b/lib/praxis/collection.rb
@@ -8,6 +8,7 @@ module Praxis
       end
 
       klass = super
+      klass.anonymous_type
 
       if type < Praxis::Types::MediaTypeCommon
         klass.member_type type

--- a/lib/praxis/docs/generator.rb
+++ b/lib/praxis/docs/generator.rb
@@ -129,7 +129,7 @@ module Praxis
         full_data = {
           info: version_info[:info],
           resources: dumped_resources,
-          schemas: nil,#dumped_schemas,
+          schemas: dumped_schemas,
           traits: version_info[:traits] || []
         }
         # Write the file

--- a/lib/praxis/docs/generator.rb
+++ b/lib/praxis/docs/generator.rb
@@ -125,7 +125,6 @@ module Praxis
         collect_reachable_types( found_media_types , collected_types );
 
         dumped_schemas = dump_schemas( collected_types )
-
         full_data = {
           info: version_info[:info],
           resources: dumped_resources,
@@ -169,9 +168,13 @@ module Praxis
       def dump_schemas(types)
         reportable_types = types - EXCLUDED_TYPES_FROM_OUTPUT
         reportable_types.each_with_object({}) do |type, array|
+          next if ( type.respond_to?(:anonymous?) && type.anonymous? )
+
           context = [type.id]
           example_data = type.example(context)
           type_output = type.describe(false, example: example_data)
+
+          type_output[:display_name] = type.display_name if type.respond_to?(:display_name)
           unless type_output[:display_name]
             # For non MediaTypes or pure types or anonymous types fallback to their name, and worst case to their id
             type_output[:display_name] = type_output[:name] || type_output[:id]

--- a/lib/praxis/extensions/field_selection/field_selector.rb
+++ b/lib/praxis/extensions/field_selection/field_selector.rb
@@ -10,6 +10,14 @@ module Praxis
             self
           end
 
+          def self.display_name
+            'FieldSelector'
+          end
+
+          def family
+            'string'
+          end
+
           def self.for(media_type)
             unless media_type < Praxis::MediaType
               raise ArgumentError, "Invalid type: #{media_type.name} for FieldSelector. " +

--- a/lib/praxis/links.rb
+++ b/lib/praxis/links.rb
@@ -57,6 +57,8 @@ module Praxis
     def self._finalize!
       super
       if @attribute
+        # Make sure the attribute gets any anonymous definition set on the links type
+        @attribute.type.anonymous_type @_anonymous
         # Master and default views must be set for all attributes, always using their :link view
         self.define_default_view
         self.define_master_view

--- a/lib/praxis/links.rb
+++ b/lib/praxis/links.rb
@@ -32,6 +32,7 @@ module Praxis
       klass = Class.new(self) do
         @reference = reference
         @links = Hash.new
+        anonymous_type
       end
 
       reference.const_set :Links, klass

--- a/lib/praxis/tasks/api_docs.rb
+++ b/lib/praxis/tasks/api_docs.rb
@@ -37,16 +37,16 @@ namespace :praxis do
       exec({'USER_DOCS_PATH' => File.join(Dir.pwd, 'docs')}, "#{path}/node_modules/.bin/grunt build --gruntfile '#{path}/Gruntfile.js'")
     end
 
-    desc "Generate API docs (JSON definitions) for a Praxis App"
-    task :generate => [:environment] do |t, args|
+    desc "Generate deprecated API docs (JSON definitions) for a Praxis App"
+    task :generate_old => [:environment] do |t, args|
       require 'fileutils'
 
       Praxis::Blueprint.caching_enabled = false
       generator = Praxis::RestfulDocGenerator.new(Dir.pwd)
     end
 
-    desc "Generate BETA API docs (JSON definitions) for a Praxis App"
-    task :generate_beta => [:environment] do |t, args|
+    desc "Generate API docs (JSON definitions) for a Praxis App"
+    task :generate => [:environment] do |t, args|
       require 'fileutils'
 
       Praxis::Blueprint.caching_enabled = false

--- a/lib/praxis/tasks/api_docs.rb
+++ b/lib/praxis/tasks/api_docs.rb
@@ -40,6 +40,7 @@ namespace :praxis do
     desc "Generate deprecated API docs (JSON definitions) for a Praxis App"
     task :generate_old => [:environment] do |t, args|
       require 'fileutils'
+      STDERR.puts "DEPRECATION: praxis:docs:generate_old is deprecated and will be removed in the next version. Please update tooling that may need this."
 
       Praxis::Blueprint.caching_enabled = false
       generator = Praxis::RestfulDocGenerator.new(Dir.pwd)
@@ -59,7 +60,7 @@ namespace :praxis do
   desc "Generate API docs (JSON definitions) for a Praxis App"
   task :api_docs do
     STDERR.puts "DEPRECATION: praxis:api_docs is deprecated and will be removed by 1.0. Please use praxis:docs:generate instead."
-    Rake::Task["praxis:docs:generate"].invoke
+    Rake::Task["praxis:docs:generate_old"].invoke
   end
 
   desc "Run API Documentation Browser"

--- a/spec/api_browser/factories/configuration_spec.js
+++ b/spec/api_browser/factories/configuration_spec.js
@@ -1,0 +1,32 @@
+describe('Configuration', function() {
+  var theConfigProvider, runFn;
+  beforeEach(function() {
+    angular.module('PraxisDocBrowser').config(function(ConfigurationProvider) {
+      theConfigProvider = ConfigurationProvider;
+    });
+    runFn = angular.module('PraxisDocBrowser')._runBlocks[0];
+  });
+
+  beforeEach(angular.mock.module('PraxisDocBrowser'));
+
+  beforeEach(inject(function(Configuration) {
+    Configuration;
+  }));
+
+  it('sets sensible defaults', function() {
+    expect(theConfigProvider).toEqual(jasmine.objectContaining({
+      title: 'API Browser',
+      versionLabel: 'API Version',
+      expandChildren: true
+    }));
+  });
+
+  it('assigns all things from the provider unto the root scope', inject(function($injector, $rootScope) {
+    $injector.invoke(runFn);
+    expect($rootScope).toEqual(jasmine.objectContaining({
+      title: 'API Browser',
+      versionLabel: 'API Version',
+      expandChildren: true
+    }));
+  }));
+});

--- a/spec/api_browser/factories/documentation_spec.js
+++ b/spec/api_browser/factories/documentation_spec.js
@@ -4,9 +4,33 @@ describe('Documentation service', function() {
   beforeEach(angular.mock.module('PraxisDocBrowser'));
 
   beforeEach(inject(function($rootScope, $injector) {
+    $httpBackend = $injector.get('$httpBackend');
+    $httpBackend.expectGET('api/index-new.json').respond({
+      versions: ['1.0', '2.0']
+    });
+    $httpBackend.expectGET('api/1.0.json').respond({
+      resources: {
+        foo: {
+
+        }
+      },
+      schemas: {
+        bar: {
+
+        }
+      }
+    });
+    $httpBackend.expectGET('api/2.0.json').respond({
+      resources: {
+        test: 'TestCTRL'
+      },
+      schemas: {
+        testType: 'TestType'
+      }
+    });
     $scope = $rootScope.$new();
     Documentation = $injector.get('Documentation');
-    $httpBackend = $injector.get('$httpBackend');
+    $httpBackend.flush();
   }));
 
   afterEach(function() {
@@ -14,37 +38,63 @@ describe('Documentation service', function() {
     $httpBackend.verifyNoOutstandingRequest();
   });
 
-  describe('#getIndex', function() {
-    var result, response = {
-      '1.0': {
-        'Blogs': {
-          'controller': 'V1-Controllers-Blogs',
-          'name': 'V1::Controllers::Blogs',
-          'media_type': 'V1-MediaTypes-Blog'
-        },
-        'Posts': {
-          'controller': 'V1-ResourceDefinitions-Posts',
-          'name': 'V1::ResourceDefinitions::Posts',
-          'media_type': 'V1-MediaTypes-Post'
-        },
-        'Users': {
-          'controller': 'V1-ResourceDefinitions-Users',
-          'name': 'V1::ResourceDefinitions::Users',
-          'media_type': 'V1-MediaTypes-User'
-        }
-      }
-    };
+  describe('#versions', function() {
+    var versions;
     beforeEach(function() {
-      $httpBackend.expectGET('api/index.json').respond(response);
-      Documentation.getIndex().then(function(data) {
-        result = data;
+      Documentation.versions().then(function(v) {
+        versions = v;
       });
-      $httpBackend.flush();
+      $scope.$apply();
+    });
+    it('returns both versions', function() {
+      expect(versions).toEqual(['1.0', '2.0']);
+    });
+  });
+
+  describe('#items', function() {
+    var items;
+    beforeEach(function() {
+      Documentation.items('1.0').then(function(data) {
+        items = data;
+      });
       $scope.$apply();
     });
 
-    it('returns the index data', function() {
-      expect(result.data).toEqual(response);
+    it('returns all items for 1.0', function() {
+      expect(items).toEqual({
+        resources: {
+          foo: { }
+        },
+        schemas: {
+          bar: {}
+        }
+      });
+    });
+  });
+  describe('#controller', function() {
+    var item;
+    beforeEach(function() {
+      Documentation.controller('2.0', 'test').then(function(data) {
+        item = data;
+      });
+      $scope.$apply();
+    });
+
+    it('returns all items for 1.0', function() {
+      expect(item).toEqual('TestCTRL');
+    });
+  });
+  describe('#type', function() {
+    var item;
+    beforeEach(function() {
+      Documentation.type('2.0', 'testType').then(function(data) {
+        item = data;
+      });
+      $scope.$apply();
+    });
+
+    it('returns all items for 1.0', function() {
+      expect(item).toEqual('TestType');
     });
   });
 });

--- a/spec/api_browser/factories/normalize_attributes_spec.js
+++ b/spec/api_browser/factories/normalize_attributes_spec.js
@@ -44,30 +44,25 @@ describe('normalizeAttributes', function() {
     test1: {
       options: {
         values: ['Hello'],
-        example: '"Hello"'
       }
     },
     test2: {
       options: {
-        example: '{\n  "test3": "Yeah",\n  "moreRecursive": {\n    "test4": 3\n  }\n}'
       },
       type: {
         attributes: {
           test3: {
             options: {
               default: 'Yeah',
-              example: '"Yeah"'
             }
           },
           moreRecursive: {
             options: {
-              example: '{\n  "test4": 3\n}'
             },
             type: {
               attributes: {
                 test4: {
                   options: {
-                    example: '3'
                   }
                 }
               }

--- a/spec/praxis/links_spec.rb
+++ b/spec/praxis/links_spec.rb
@@ -19,6 +19,11 @@ describe Praxis::Links do
     expect(link.for(Address)).to eq(link)
   end
 
+  it 'are marked as anonymous' do
+    described = link.for(Address).describe
+    expect(described[:anonymous]).to be(true)
+  end
+
   context 'contents' do
     subject(:view) { link.view(:default) }
 


### PR DESCRIPTION
This patch adds support for the new docs format, which allows us to
expose traits and request and response examples. 

Several issues are fixed with this release, namely:

- issues with scrolling and mobile
resolutions
- adds a missing standalone array family template
- adds slightly better practice for SEO. 

The design has been switched back to a page per action, as the pages became untenably long.