### PR TITLE
Handle versions with all resources `nodoc!’d`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ resource definition.
   * Displays more detailed HTML titles.
   * Has been switched back to having a separate page per action, however actions are now shown in the sidebar.
   * Will now display multiply nested resources in a proper hierarchy.
+* Fix doc generator to only output versions in index for which we have resources (i.e. some can be nodoc!)
 
 ## 0.18.1
 

--- a/lib/praxis/docs/generator.rb
+++ b/lib/praxis/docs/generator.rb
@@ -35,7 +35,8 @@ module Praxis
       end
 
       def save!
-        write_index_file
+        # Restrict the versions listed in the index file to the ones for which we have at least 1 resource
+        write_index_file( for_versions: resources_by_version.keys )
         resources_by_version.keys.each do |version|
           write_version_file(version)
         end
@@ -97,9 +98,9 @@ module Praxis
         reachable_types
       end
 
-      def write_index_file
+      def write_index_file( for_versions:  )
         # Gather the versions
-        versions = infos_by_version.keys.reject{|v| v == :global || v == :traits }.map do |version|
+        versions = infos_by_version.keys.reject{|v| v == :global || v == :traits || !for_versions.include?(v) }.map do |version|
           version == "n/a" ? "unversioned" : version
         end
         data = {


### PR DESCRIPTION
* Make generator to skip reporting versions in index for which we have no resources (after applying the nodoc! directive)

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>