### PR TITLE
Fixes potential missing schemas from doc gen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   which allows plugins to register assets that will be included in the doc browser.
   This is a convenient way to share customizations and optional features amongst
   different API projects.
+* Fixed a corner-case in doc generation which could omit certain existing MediaTypes
+  (when these existed but there were never referenced in any other part of the app).
 
 ## 0.19.0
 

--- a/lib/praxis/docs/generator.rb
+++ b/lib/praxis/docs/generator.rb
@@ -122,8 +122,10 @@ module Praxis
         found_media_types =  resources_by_version[version].select{|r| r.media_type}.collect {|r| r.media_type.describe }
 
         collected_types = Set.new
-        collect_reachable_types( dumped_resources, collected_types );
-        collect_reachable_types( found_media_types , collected_types );
+        collect_reachable_types( dumped_resources, collected_types )
+        found_media_types.each do |mt|
+          collect_reachable_types( { type: mt} , collected_types )
+        end
 
         dumped_schemas = dump_schemas( collected_types )
         full_data = {


### PR DESCRIPTION
This could happen for Mts that existed but that
there were never referenced in any other part of the app.

Fixes #273

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>