### PR TITLE
Code examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   different API projects.
 * Fixed a corner-case in doc generation which could omit certain existing MediaTypes
   (when these existed but there were never referenced in any other part of the app).
+* Doc Browser now exposes an API to register functions that generate code examples.
+  These can be registered with `ExamplesProvider.register` call.
 
 ## 0.19.0
 

--- a/lib/api_browser/Gruntfile.js
+++ b/lib/api_browser/Gruntfile.js
@@ -215,6 +215,9 @@ module.exports = function(grunt) {
               if (object && object.type === 'Identifier' && object.name === 'templateForProvider' && node.callee.property.name === 'register') {
                 return node.arguments[0];
               }
+              if (object && object.type === 'Identifier' && object.name === 'ExamplesProvider' && node.callee.property.name === 'register') {
+                return node.arguments[2];
+              }
             }
           }}]
         }
@@ -443,7 +446,7 @@ module.exports = function(grunt) {
 
         // Updates index.html for any bower component added or removed
         bowerComponents: {
-          files: ['app/bower_components/**/*', userDocsPath + '/bower_components/**/*'],
+          files: ['app/bower_components/**/.bower.json'],
           tasks: 'wiredep',
           options: { livereload: 9091 }
         },

--- a/lib/api_browser/app/index.html
+++ b/lib/api_browser/app/index.html
@@ -6,8 +6,10 @@
   <title ng-bind="subtitle ? title + ' – ' + subtitle : title">API Browser</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width">
+  <!-- build:css({.tmp,app,/}) css/other.css -->
   <!-- bower:css -->
   <!-- endbower -->
+  <!-- endbuild -->
   <link rel="stylesheet" href="css/main.css">
 </head>
 <body>

--- a/lib/api_browser/app/js/directives/highlight.js
+++ b/lib/api_browser/app/js/directives/highlight.js
@@ -1,0 +1,11 @@
+app.directive('highlight', function() {
+  return {
+    restrict: 'EA',
+    link: function ($scope, element, attrs) {
+      element.ready(function() {
+        var prism = window.Prism;
+        element.html('<code>' + prism.highlight(element.text(), prism.languages[attrs.highlight], attrs.highlight) + '</code>');
+      });
+    }
+  };
+});

--- a/lib/api_browser/app/js/directives/highlight.js
+++ b/lib/api_browser/app/js/directives/highlight.js
@@ -2,9 +2,12 @@ app.directive('highlight', function() {
   return {
     restrict: 'EA',
     link: function ($scope, element, attrs) {
+      var prism = window.Prism;
+      prism.plugins.autoloader.languages_path = 'https://cdn.jsdelivr.net/prism/1.3.0/components/';
       element.ready(function() {
-        var prism = window.Prism;
-        element.html('<code>' + prism.highlight(element.text(), prism.languages[attrs.highlight], attrs.highlight) + '</code>');
+        element.html('<code>' + element.text() + '</code>');
+        element.addClass('language-' + attrs.highlight);
+        prism.highlightElement(element.find('code')[0]);
       });
     }
   };

--- a/lib/api_browser/app/js/directives/request_examples.js
+++ b/lib/api_browser/app/js/directives/request_examples.js
@@ -1,0 +1,29 @@
+app.directive('requestExamples', function(Examples, $timeout) {
+  return {
+    restrict: 'E',
+    scope: {
+      action: '=',
+      resource: '=',
+      version: '='
+    },
+    template: '<tabset><tab ng-repeat="example in examples" heading="{{example.displayName}}" select="select(example.template)"></tab></tabset>',
+    link: function(scope, element) {
+      scope.examples = Examples.forContext(scope.action, scope.version, scope.resource);
+      var keys = _.keys(scope.examples);
+      if (keys.length === 1) {
+        scope.examples[keys[0]].template.then(function(templateFn) {
+          element.empty().append(templateFn(scope));
+        });
+      } else {
+        scope.select = function(template) {
+          template.then(function(templateFn) {
+            $timeout(function() {
+              element.find('.tab-content:eq(0)>.tab-pane.active:not(.initialized)').append(templateFn(scope)).addClass('initialized');
+              template.then = _.noop;
+            }, 100);
+          });
+        };
+      }
+    }
+  };
+});

--- a/lib/api_browser/app/js/factories/Documentation.js
+++ b/lib/api_browser/app/js/factories/Documentation.js
@@ -18,6 +18,12 @@ app.factory('Documentation', function($http, $q) {
       return versions.then(_.keys);
     },
     /**
+     * Returns the info for the requested version
+     */
+    info: function(version) {
+      return versions.then(function(v) { return v[version].info; });
+    },
+    /**
      * Returns a list of controllers and types, useful for generating navigation
      */
     items: function(version) {

--- a/lib/api_browser/app/js/factories/Example.js
+++ b/lib/api_browser/app/js/factories/Example.js
@@ -1,0 +1,42 @@
+app.provider('Examples', function() {
+  var registry = {};
+
+  this.register = function(key, displayName, handler) {
+    registry[key] = registry[key] || [];
+    registry[key].unshift({
+      key: key,
+      displayName: displayName,
+      handler: handler
+    });
+  };
+
+  this.register('general', 'General', function() {
+    return 'views/examples/general.html';
+  });
+
+  this.$get = function(prepareTemplate, $injector) {
+    return {
+      forContext: function(action, version) {
+        var results = {};
+        for (var key in registry) {
+          for (var i = 0; i < registry[key].length; i++) {
+            var result = $injector.invoke(registry[key][i].handler, this, {
+              $action: action,
+              $version: version
+            });
+            if (result) {
+              results[key] = {
+                key: key,
+                displayName: registry[key][i].displayName,
+                template: prepareTemplate(result)
+              };
+              break;
+            }
+          }
+        }
+        return results;
+      }
+    };
+  };
+
+});

--- a/lib/api_browser/app/js/factories/Example.js
+++ b/lib/api_browser/app/js/factories/Example.js
@@ -16,13 +16,18 @@ app.provider('Examples', function() {
 
   this.$get = function(prepareTemplate, $injector) {
     return {
-      forContext: function(action, version) {
+      forContext: function(action, version, resource) {
         var results = {};
         for (var key in registry) {
           for (var i = 0; i < registry[key].length; i++) {
             var result = $injector.invoke(registry[key][i].handler, this, {
               $action: action,
-              $version: version
+              $version: version,
+              $context: {
+                resource: resource,
+                action: action,
+                version: version
+              }
             });
             if (result) {
               results[key] = {

--- a/lib/api_browser/app/js/factories/prepare_template.js
+++ b/lib/api_browser/app/js/factories/prepare_template.js
@@ -1,0 +1,15 @@
+app.factory('prepareTemplate', function($q, $http, $templateCache, $compile) {
+  return function(result) {
+    return $q.when(result).then(function(template) {
+      if (_.isFunction(template)) {
+        return template;
+      } else if (_.isString(template)) {
+        return $http.get(template, {cache: $templateCache}).then(function(response) {
+          return $compile(response.data);
+        });
+      } else {
+        throw 'Resolver returned an unknown type';
+      }
+    });
+  };
+});

--- a/lib/api_browser/app/js/factories/template_for.js
+++ b/lib/api_browser/app/js/factories/template_for.js
@@ -80,7 +80,7 @@ app.provider('templateFor', function() {
     }
   });
 
-  this.$get = function($q, $http, $injector, $compile, $templateCache) {
+  this.$get = function($injector, prepareTemplate) {
     return function(type, templateType) {
       for (var i = 0; i < resolvers.length; i++) {
         var result = $injector.invoke(resolvers[i], this, {
@@ -90,17 +90,7 @@ app.provider('templateFor', function() {
           $requestedTemplate: templateType
         });
         if (result) {
-          return $q.when(result).then(function(template) {
-            if (_.isFunction(template)) {
-              return template;
-            } else if (_.isString(template)) {
-              return $http.get(template, {cache: $templateCache}).then(function(response) {
-                return $compile(response.data);
-              });
-            } else {
-              throw 'Resolver returned an unknown type';
-            }
-          });
+          return prepareTemplate(result);
         }
       }
       throw 'Template did not match any resolver.';

--- a/lib/api_browser/app/views/action.html
+++ b/lib/api_browser/app/views/action.html
@@ -40,29 +40,7 @@
   <div class="row">
     <div class="col-lg-12">
       <h2>Request Example</h2>
-      <div ng-if="!action.payload.examples">
-        <h4>URL</h4>
-        <url action="action" example></url>
-        <div ng-if="action.headers.example">
-          <h4>Headers</h4>
-          <pre><span ng-repeat="(header, value) in action.headers.example">{{header}}: {{value}}
-</span></pre>
-        </div>
-      </div>
-      <tabset ng-if="action.payload.examples">
-        <tab ng-repeat="(type, example) in action.payload.examples" heading="{{type}}">
-          <h4>URL</h4>
-          <url action="action" example></url>
-          <div ng-if="action.headers.example">
-            <h4>Headers</h4>
-            <pre><span ng-if="example.content_type">Content-Type: {{example.content_type}}
-</span><span ng-repeat="(header, value) in action.headers.example">{{header}}: {{value}}
-</span></pre>
-          </div>
-          <h4>Request body</h4>
-          <pre>{{ example.body }}</pre>
-        </tab>
-      </tabset>
+      <request-examples action="action" resource="controller" version="apiVersion"></request-examples>
     </div>
   </div>
 

--- a/lib/api_browser/app/views/action.html
+++ b/lib/api_browser/app/views/action.html
@@ -51,7 +51,11 @@
         <div class="panel-heading"><h4 class="panel-title">{{response.name}}</h4></div>
         <div class="panel-body">
           <div class="row">
-            <div class="col-md-4">
+            <div ng-class="{'col-md-4': response.payload.examples, 'col-md-12': !response.payload.examples}">
+              <div ng-if="response.description && response.description != ''">
+                <h5>Description</h5>
+                <div ng-bind-html="response.description | markdown"></div>
+              </div>
               <h5>Status</h5>
               <p>{{ response.status }}</p>
               <div ng-if="response.examples.json">

--- a/lib/api_browser/app/views/examples/general.html
+++ b/lib/api_browser/app/views/examples/general.html
@@ -1,0 +1,26 @@
+<div ng-if="!action.payload.examples">
+  <h4>URL</h4>
+  <url action="action" example></url>
+  <div ng-if="action.headers.example">
+    <h4>Headers</h4>
+    <pre><span ng-repeat="(header, value) in action.headers.example">{{header}}: {{value}}
+</span></pre>
+  </div>
+</div>
+<div ng-if="action.payload.examples">
+  <h4>URL</h4>
+  <url action="action" example></url>
+  <h4>Encoding</h4>
+  <tabset type="pills">
+    <tab ng-repeat="(type, example) in action.payload.examples" heading="{{type}}">
+      <div ng-if="action.headers.example">
+        <h4>Headers</h4>
+        <pre><span ng-if="example.content_type">Content-Type: {{example.content_type}}
+</span><span ng-repeat="(header, value) in action.headers.example">{{header}}: {{value}}
+</span></pre>
+      </div>
+      <h4>Request body</h4>
+      <pre>{{ example.body }}</pre>
+    </tab>
+  </tabset>
+</div>

--- a/lib/api_browser/bower_template.json
+++ b/lib/api_browser/bower_template.json
@@ -23,7 +23,8 @@
     "angular-ui-router": "~0.2.10",
     "angular-ui-bootstrap-bower": "~0.13.4",
     "angular-sanitize": "~1.4",
-    "showdown": "~0.4.0"
+    "showdown": "~0.4.0",
+    "prism": "~1.3.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.4.0"

--- a/lib/api_browser/bower_template.json
+++ b/lib/api_browser/bower_template.json
@@ -28,5 +28,14 @@
   },
   "devDependencies": {
     "angular-mocks": "~1.4.0"
+  },
+  "overrides": {
+    "prism": {
+      "main": [
+          "prism.js",
+          "themes/prism.css",
+          "plugins/autoloader/prism-autoloader.js"
+      ]
+    }
   }
 }


### PR DESCRIPTION
![praxis-code-examples](https://cloud.githubusercontent.com/assets/69144/12356183/1577588e-bb99-11e5-94f0-c5a5fd2bd6df.gif)

This PR adds an API that users/plugins can hook into to generate code examples for the doc browser. These can either be specific hand written ones, or they can be generic functions that simply generate the appropriate code. This [gist](https://gist.github.com/gampleman/672bc02860694d90aa5d) shows an example of a code generator.