### PR TITLE
drop ruby 2.1 and add ruby 2.3 to ruby versions in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 2.1.5
-  - 2.2.2
+  - 2.2.4
+  - 2.3.0
 node_js:
   - "0.10"
 branches:


### PR DESCRIPTION
Signed-off-by: Dane Jensen <dane@rightscale.com>