### PR TITLE
Assorted fixes:

### DIFF
--- a/lib/praxis/api_definition.rb
+++ b/lib/praxis/api_definition.rb
@@ -98,7 +98,8 @@ module Praxis
         description 'Standard response for successful HTTP requests.'
       end
 
-      api.response_template :created do |location: nil|
+      api.response_template :created do |location: nil, media_type: nil|
+        media_type media_type if media_type
         location location
         status 201
         description 'The request has been fulfilled and resulted in a new resource being created.'

--- a/lib/praxis/docs/generator.rb
+++ b/lib/praxis/docs/generator.rb
@@ -2,6 +2,8 @@ module Praxis
   module Docs
 
     class Generator
+      require 'active_support/core_ext/enumerable' # For index_by
+
       API_DOCS_DIRNAME = 'docs/api'
 
       attr_reader :resources_by_version, :types_by_id, :infos_by_version
@@ -11,6 +13,7 @@ module Praxis
         Attributor::Boolean,
         Attributor::CSV,
         Attributor::DateTime,
+        Attributor::Date,
         Attributor::Float,
         Attributor::Hash,
         Attributor::Ids,
@@ -85,9 +88,9 @@ module Praxis
         when Hash
           if data.key?(:type) && data[:type].kind_of?(Hash) && ( [:id,:name,:family] - data[:type].keys ).empty?
             type_id = data[:type][:id]
-            unless type_id.nil?
+            unless type_id.nil? || type_id == Praxis::SimpleMediaType.id #SimpleTypes shouldn't be collected
               unless types_by_id[type_id]
-                raise "Error! We have detected a reference to a 'Type' which is not derived from Attributor::Type" +
+                raise "Error! We have detected a reference to a 'Type' with id='#{type_id}' which is not derived from Attributor::Type" +
                       " Document generation cannot proceed."
               end
               reachable_types << types_by_id[type_id]

--- a/lib/praxis/simple_media_type.rb
+++ b/lib/praxis/simple_media_type.rb
@@ -6,13 +6,19 @@ module Praxis
   # @see Praxis::MediaType
   # @see Praxis::Types::MediaTypeCommon
   SimpleMediaType = Struct.new(:identifier) do
+
     def name
       self.class.name
     end
 
-    def id
-      self.class.name.gsub("::",'-')
+    def self.id
+      "Praxis-SimpleMediaType".freeze
     end
+
+    def id
+      self.class.id
+    end
+
 
     def describe(shallow=true)
       {name: name, family: "string", id: id, identifier: identifier}


### PR DESCRIPTION
* Doc generation: handle SimpleMediaTypes so that they don’t show up in the generated schemas. Fixes #283
* ensure we require AS#Enumerable extension is loaded, which is required in the generator code.
* Add Date to the list of primitive types so that it does not show in the generated schemas.
* enhaneg the `:created` response_template, so that it can take the associated media_type


Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>