### PR TITLE
Fix name in Doc browser's controller heading

### DIFF
--- a/lib/api_browser/app/views/controller.html
+++ b/lib/api_browser/app/views/controller.html
@@ -5,7 +5,7 @@
   <div class="row">
     <div class="col-lg-12">
       <h1 class="page-header">
-        {{ controller.display_name | resourceName }}
+        {{ controller.display_name || (controller.name | resourceName) }}
       </h1>
 
       <p ng-bind-html="controller.description | markdown"></p>

--- a/lib/api_browser/app/views/controller.html
+++ b/lib/api_browser/app/views/controller.html
@@ -5,7 +5,7 @@
   <div class="row">
     <div class="col-lg-12">
       <h1 class="page-header">
-        {{ controller.name | resourceName }}
+        {{ controller.display_name | resourceName }}
       </h1>
 
       <p ng-bind-html="controller.description | markdown"></p>


### PR DESCRIPTION
Use the appropriate `display_name` string in the heading of the resource page (like we do for the nav bar)

@gampleman can you please review and merge if appropriate?

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>