### PR TITLE
Correct graying of attribute names in deep nesting

### DIFF
--- a/lib/api_browser/app/js/filters/attribute_name.js
+++ b/lib/api_browser/app/js/filters/attribute_name.js
@@ -1,8 +1,9 @@
 app.filter('attributeName', function($sce) {
   return function(input) {
     var parts = input.split('.');
-    if (parts.length == 2) {
-      return $sce.trustAsHtml('<span class="attribute-prefix">' + parts[0] + '.</span>' + parts[1]);
+    if (parts.length > 1) {
+      var prefix = parts.slice(0,parts.length-1).join('.')
+      return $sce.trustAsHtml('<span class="attribute-prefix">' + prefix + '.</span>' + parts[parts.length-1]);
     }
     return $sce.trustAsHtml(input);
   };

--- a/lib/api_browser/app/js/filters/attribute_name.js
+++ b/lib/api_browser/app/js/filters/attribute_name.js
@@ -2,8 +2,8 @@ app.filter('attributeName', function($sce) {
   return function(input) {
     var parts = input.split('.');
     if (parts.length > 1) {
-      var prefix = parts.slice(0,parts.length-1).join('.')
-      return $sce.trustAsHtml('<span class="attribute-prefix">' + prefix + '.</span>' + parts[parts.length-1]);
+      var prefix = _.take(parts, parts.length-1).join('.');
+      return $sce.trustAsHtml('<span class="attribute-prefix">' + prefix + '.</span>' + _.last(parts));
     }
     return $sce.trustAsHtml(input);
   };


### PR DESCRIPTION
Properly gray the prefix of attribute names in a table when there are more than 2 nested hashes/structs.


Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>