### PR TITLE
Field expansion supports no-parameter actions

### DIFF
--- a/lib/praxis/extensions/field_expansion.rb
+++ b/lib/praxis/extensions/field_expansion.rb
@@ -17,8 +17,8 @@ module Praxis
         extend ActiveSupport::Concern
 
         def expanded_fields(request, media_type)
-          use_fields = self.params.attributes.key?(:fields)
-          use_view = self.params.attributes.key?(:view)
+          use_fields = self.params && self.params.attributes.key?(:fields)
+          use_view = self.params && self.params.attributes.key?(:view)
 
           # Determine what, if any, fields to display.
           fields = if use_fields

--- a/spec/praxis/extensions/field_expansion_spec.rb
+++ b/spec/praxis/extensions/field_expansion_spec.rb
@@ -91,6 +91,16 @@ describe Praxis::Extensions::FieldExpansion do
         end
       end
     end
+
+
+    context 'with an action with no params' do
+      let(:test_params) { nil }
+      let(:fields){ nil }
+      let(:view){ nil }
+      it 'ignores incoming parameters and expands for the default view' do
+        expect(expansion).to eq({id: true, name: true, links: [true]})
+      end
+    end
   end
 
 end


### PR DESCRIPTION

Make sure the field expansion extension still works for actions where no parameters are defined (in which cases expands to the default view)

fixes #300

Signed-off-by: Josep M. Blanquer <blanquer@rightscale.com>