### PR TITLE
Resources inherit APIDefinition `base_params` properly and lazily.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 * Allow Plugin registration without requiring config_key
   * registration will select a default config_key based on the class name
 * Make Traits accumulate block definitions for `params`,`headers` and `payload` rather than overriding them.
+* Switch to lazy evaluation of `base_params` from `ApiDefinition` to properly inherit them into the resources
+  and their corresponding actions even before the application's `MediaTtypes` have been finalized.
 
 
 ## 0.20.1

--- a/lib/praxis/action_definition.rb
+++ b/lib/praxis/action_definition.rb
@@ -118,14 +118,6 @@ module Praxis
         update_attribute(@params, opts, block)
       else
         @params = create_attribute(type, **opts, &block)
-        if (api_info = ApiDefinition.instance.info(resource_definition.version))
-          if api_info.base_params
-            base_attrs = api_info.base_params.attributes
-            @params.attributes.merge!(base_attrs) do |key, oldval, newval|
-              oldval
-            end
-          end
-        end
       end
 
       @params

--- a/lib/praxis/resource_definition.rb
+++ b/lib/praxis/resource_definition.rb
@@ -39,7 +39,7 @@ module Praxis
     def self.generate_defaults_block( version: nil )
 
       # Ensure we inherit any base params defined in the API definition for the passed in version
-      base_attributes = if base_params = ApiDefinition.instance.info(version).base_params
+      base_attributes = if (base_params = ApiDefinition.instance.info(version).base_params)
         base_params.attributes
       else
         {}

--- a/lib/praxis/resource_definition.rb
+++ b/lib/praxis/resource_definition.rb
@@ -12,11 +12,7 @@ module Praxis
       @actions = Hash.new
       @responses = Hash.new
 
-      # Ensure we inherit any base params defined in the API definition for this version
-      base_attrs = if base_params = ApiDefinition.instance.info.base_params
-        base_params.attributes
-      end
-      @action_defaults = Trait.new &ResourceDefinition.generate_defaults_block( base_attrs || {} )
+      @action_defaults = Trait.new &ResourceDefinition.generate_defaults_block
 
       @version_options = {}
       @metadata = {}
@@ -40,7 +36,15 @@ module Praxis
       Application.instance.resource_definitions << self
     end
 
-    def self.generate_defaults_block( base_attributes )
+    def self.generate_defaults_block( version: nil )
+
+      # Ensure we inherit any base params defined in the API definition for the passed in version
+      base_attributes = if base_params = ApiDefinition.instance.info(version).base_params
+        base_params.attributes
+      else
+        {}
+      end
+
       Proc.new do
         unless base_attributes.empty?
           params do
@@ -195,11 +199,7 @@ module Praxis
           end
         end
 
-        # Ensure we inherit any base params defined in the API definition for this version
-        base_attrs = if base_params = ApiDefinition.instance.info(version).base_params
-          base_params.attributes
-        end
-        @action_defaults.instance_eval &ResourceDefinition.generate_defaults_block( base_attrs || {} )
+        @action_defaults.instance_eval &ResourceDefinition.generate_defaults_block( version: version )
       end
 
 

--- a/spec/praxis/action_definition_spec.rb
+++ b/spec/praxis/action_definition_spec.rb
@@ -340,7 +340,7 @@ describe Praxis::ActionDefinition do
     end
 
     its('routes.first.path.to_s') { should eq '/apps/:app_name/foobars/hello_world/:one' }
-    its('params.attributes.keys') { should eq [:inherited, :app_name, :one]}
+    its('params.attributes.keys') { should match_array [:inherited, :app_name, :one]}
 
     context 'where the action overrides a base_param' do
 

--- a/spec/praxis/resource_definition_spec.rb
+++ b/spec/praxis/resource_definition_spec.rb
@@ -110,6 +110,9 @@ describe Praxis::ResourceDefinition do
           base_path '/api/:base_param'
           base_params do
             attribute :base_param, String
+            attribute :grouped_params do
+              attribute :nested_param, String
+            end
           end
         end
 
@@ -142,6 +145,10 @@ describe Praxis::ResourceDefinition do
 
       it 'including globally defined' do
         expect(show_action_params.attributes).to have_key(:base_param)
+        expect(show_action_params.attributes).to have_key(:grouped_params)
+        grouped = show_action_params.attributes[:grouped_params]
+        expect(grouped.type.ancestors).to include(::Attributor::Struct)
+        expect(grouped.type.attributes.keys).to eq([:nested_param])
       end
       it 'including the ones defined for its own version' do
         expect(show_action_params.attributes).to have_key(:app_name)


### PR DESCRIPTION
Trigger Resources to "inherit" any of the defined `base_params` in the APIDefinition, both global ones as well as the ones defined for the same version of the resource. Inheritance is done through incorporating them into `action_defaults` so that any action defined in the resource will automatically copy them as usual.

That is instead of the special-casing of attribute merging done at the time of “params” definition for an action. That would occasionally blow up since it is not delayed and some reference MediaTypes would not have been finalized yet.

Fixes #308

Signed-off-by: Josep M. Blanquer <blanquer@gmail.com>