### PR TITLE
Helper for Praxis as an intercepting Middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 * Make Traits accumulate block definitions for `params`,`headers` and `payload` rather than overriding them.
 * Switch to lazy evaluation of `base_params` from `ApiDefinition` to properly inherit them into the resources
   and their corresponding actions even before the application's `MediaTtypes` have been finalized.
+* Built the `MiddlewareApp` class to make it easy to run a Praxis app mounted as an intercepting
+  middleware which will only forward requests down the stack if they didn't match any of its routes.
+  * Note: it properly skips forwarding when 404s are purposedly returned by the application itself.
+  * Note2: it also respects the `X-Cascade=pass` conventions.
 
 
 ## 0.20.1

--- a/lib/praxis.rb
+++ b/lib/praxis.rb
@@ -45,6 +45,7 @@ module Praxis
 
   autoload :Stats, 'praxis/stats'
   autoload :Notifications, 'praxis/notifications'
+  autoload :MiddlewareApp, 'praxis/middleware_app'
 
   autoload :RestfulDocGenerator, 'praxis/restful_doc_generator'
   module Docs

--- a/lib/praxis/middleware_app.rb
+++ b/lib/praxis/middleware_app.rb
@@ -5,7 +5,7 @@ module Praxis
 
     # Initialize the application instance with the desired args, and return the wrapping class.
     def self.for( **args )
-      Praxis::Application.instance.setup(args)
+      Praxis::Application.instance.setup(**args)
       self
      end
 

--- a/lib/praxis/middleware_app.rb
+++ b/lib/praxis/middleware_app.rb
@@ -1,0 +1,30 @@
+module Praxis
+  class MiddlewareApp
+
+    attr_reader :target
+
+    # Initialize the application instance with the desired args, and return the wrapping class.
+    def self.for( **args )
+      Praxis::Application.instance.setup(args)
+      self
+     end
+
+    def initialize( inner )
+      @target = inner
+    end
+
+    def call(env)
+      result = Praxis::Application.instance.call(env)
+
+      unless ( [404,405].include?(result[0].to_i) && result[1]['X-Cascade'] == 'pass' )
+        # Respect X-Cascade header if it doesn't specify 'pass'
+        result
+      else
+        last_body = result[2]
+        last_body.close if last_body.respond_to? :close
+        target.call(env)
+      end
+    end
+
+  end
+end

--- a/spec/praxis/middleware_app_spec.rb
+++ b/spec/praxis/middleware_app_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe Praxis::MiddlewareApp do
+
+  context '.for' do
+    let(:init_args){ { root: 'here'} }
+    subject(:middleware) { Praxis::MiddlewareApp.for( init_args ) }
+
+    it 'initializes the application singletone with the passed parameters' do
+      expect( Praxis::Application.instance ).to receive(:setup).with( init_args ).once
+      subject
+    end
+    it 'returns its class' do
+      expect( subject ).to be( Praxis::MiddlewareApp )
+    end
+  end
+
+  context 'instantiated' do
+    let(:target_response){ [201,{}] }
+    let(:target){ double("target app", call: target_response) }
+    subject(:instance){ Praxis::MiddlewareApp.new(target)}
+    it 'saves the target app' do
+      expect(subject.target).to be(target)
+    end
+    context '.call' do
+      let(:env){ {} }
+      let(:praxis_response){ [200,{}] }
+      subject(:response){ Praxis::MiddlewareApp.new(target).call(env) }
+      before do
+        # always invokes the praxis app
+        expect( Praxis::Application.instance ).to receive(:call).with( env ).once.and_return(praxis_response)
+      end
+
+      context 'properly handled (non-404 and 405) responses from praxis' do
+        it 'are returned straight through' do
+          expect( response ).to be(praxis_response)
+        end
+      end
+
+      context '404/405 responses with X-Cascade = pass' do
+        let(:praxis_response){ [404, {'X-Cascade' => 'pass'}]}
+        it 'are forwarded to the target app' do
+          expect( response ).to be(target_response)
+        end
+      end
+
+      context '404/405 responses without X-Cascade = pass' do
+        let(:praxis_response){ [404, {}]}
+        it 'returned straight through' do
+          expect( response ).to be(praxis_response)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Build a helper to mount a Praxis application as an intercepting middleware which would handle requests, and only forward requests that cannot be properly handled by it (respecting X-Cascade).